### PR TITLE
fix: import error on wrong path

### DIFF
--- a/src/types/pixiv-ugoira.ts
+++ b/src/types/pixiv-ugoira.ts
@@ -1,4 +1,4 @@
-import { BaseSimpleCheck, CheckFunctions } from 'src/checks'
+import { BaseSimpleCheck, CheckFunctions } from '../checks'
 
 /**
  * 圧縮されたフレームのURL


### PR DESCRIPTION
こんにちは。お疲れ様でした。
現時点のバーションには、ランタイムエラーが発生してしまいます：

```
> require("@book000/pixivts")
Uncaught Error: Cannot find module 'src/checks'
Require stack:
- /home/xxx/Programs/yyy/node_modules/@book000/pixivts/dist/types/pixiv-ugoira.js
- /home/xxx/Programs/yyy/node_modules/@book000/pixivts/dist/types/endpoints/v1/illust/ugoira/metadata.js
- /home/xxx/Programs/yyy/node_modules/@book000/pixivts/dist/index.js
- <repl>
    at Module._resolveFilename (node:internal/modules/cjs/loader:1077:15)
    at Module._load (node:internal/modules/cjs/loader:922:27)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:119:18) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/xxx/Programs/yyy/node_modules/@book000/pixivts/dist/types/pixiv-ugoira.js',
    '/home/xxx/Programs/yyy/node_modules/@book000/pixivts/dist/types/endpoints/v1/illust/ugoira/metadata.js',
    '/home/xxx/Programs/yyy/node_modules/@book000/pixivts/dist/index.js',
    '<repl>'
  ]
}
```

原因は、#211 のPRによるimport文の設定ミスと見られています：
https://github.com/book000/pixivts/blob/525626232340f7f1b25a131982a12fa420338188/src/types/pixiv-ugoira.ts#L1

このPRでは、正しいインポートパスを設定するための修正を提案しています。
ご迷惑をおかけしてすみませんでした。よろしくお願いします。