### PR TITLE
fix: save response to include query parameters

### DIFF
--- a/src/pixiv.ts
+++ b/src/pixiv.ts
@@ -789,7 +789,13 @@ export default class Pixiv {
     }
     const method = request.method
     const path = request.path
-    const url = this.hosts + path
+    const url = [
+      this.hosts,
+      path,
+      method === 'GET'
+        ? qs.stringify(request.params, { addQueryPrefix: true })
+        : '',
+    ].join('')
 
     const responseType = this.isJSON(response.data) ? 'JSON' : 'TEXT'
     const responseBody =


### PR DESCRIPTION
in GET requests