### PR TITLE
fix(ci): npm パッケージに dist/ が含まれない問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,9 @@ jobs:
         run: |
           pnpm version --no-git-tag-version ${{ steps.tag-version.outputs.new_version }}
 
+      - name: 🔬 Lint
+        run: pnpm run lint
+
       - name: 📦 Publish
         run: |
           pnpm publish --access public --no-git-checks --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,21 @@ jobs:
       - name: 🏃 Build
         run: pnpm run build
 
+      - name: 🔍 Verify dist contents
+        run: |
+          test -f dist/index.js
+          test -f dist/index.d.ts
+
+      - name: 📦 Verify pack contents
+        run: |
+          mkdir -p /tmp/pack-check
+          pnpm pack --pack-destination /tmp/pack-check
+          TARBALL=$(ls /tmp/pack-check/*.tgz | head -1)
+          echo "Inspecting $TARBALL"
+          tar -tzf "$TARBALL" | tee /tmp/pack-files.txt
+          grep -q '^package/dist/index.js$' /tmp/pack-files.txt
+          grep -q '^package/dist/index.d.ts$' /tmp/pack-files.txt
+
       - name: 🏷 Bump version and push tag
         id: tag-version
         uses: mathieudutour/github-tag-action@v6.2
@@ -76,7 +91,7 @@ jobs:
 
       - name: 📦 Publish
         run: |
-          pnpm publish --access public --no-git-checks
+          pnpm publish --access public --no-git-checks --ignore-scripts
 
       - name: 📃 Create Release
         id: create_release

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "repository": "git@github.com:book000/pixivts.git",
   "scripts": {
     "build": "run-z clean ctix compile generate-docs",
-    "clean": "rimraf dist output docs tsconfig.build.tsbuildinfo",
+    "clean": "rimraf dist output docs tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
     "compile": "tsc -p tsconfig.build.json",
     "ctix": "ctix single -w --noBackup -o src -s false",
     "generate-docs": "typedoc --gitRevision master src/index.ts",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "repository": "git@github.com:book000/pixivts.git",
   "scripts": {
     "build": "run-z clean ctix compile generate-docs",
-    "clean": "rimraf dist output docs",
+    "clean": "rimraf dist output docs tsconfig.build.tsbuildinfo",
     "compile": "tsc -p tsconfig.build.json",
     "ctix": "ctix single -w --noBackup -o src -s false",
     "generate-docs": "typedoc --gitRevision master src/index.ts",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 allowBuilds:
   unrs-resolver: true
+minimumReleaseAgeExclude:
+  - '@book000/*'


### PR DESCRIPTION
## 概要

v0.46.49 以降のすべての公開 npm パッケージで `dist/` ディレクトリが含まれず、利用側プロジェクトで `Cannot find module '@book000/pixivts' or its corresponding type declarations.` が発生していた問題を修正します。

## 原因

TypeScript v6 の incremental ビルドの挙動変化が根本原因です。

**問題の流れ:**
1. `pnpm install` → `prepare` スクリプトが `build` を実行 → `dist/` と `tsconfig.build.tsbuildinfo` が生成される
2. `pnpm run build` (ワークフロー) → `clean` で `dist/` を削除するが `tsconfig.build.tsbuildinfo` は残る
3. `tsc -p tsconfig.build.json` → tsbuildinfo が「変更なし」と判断してコンパイルをスキップ → **dist/ が空のまま**
4. `pnpm publish` → `dist/` が存在しないため tarball に含まれない

ローカルで再現確認済み:
```sh
# tsbuildinfo あり、dist なし → tsc が dist を生成しない
$ pnpm run clean && pnpm run compile && ls dist 2>/dev/null || echo "dist/ MISSING"
# → dist/ MISSING

# tsbuildinfo なし、dist なし → tsc が dist を正常生成
$ rm tsconfig.build.tsbuildinfo && pnpm run compile && ls dist | wc -l
# → 42
```

## 変更内容

### `package.json`

`clean` スクリプトに `tsconfig.tsbuildinfo` と `tsconfig.build.tsbuildinfo` の削除を追加。

```diff
-"clean": "rimraf dist output docs"
+"clean": "rimraf dist output docs tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo"
```

これにより `build` を再実行するたびに tsbuildinfo も消去され、tsc が必ずフルコンパイルを行うようになります。

### `.github/workflows/release.yml`

1. **ビルド成果物の検証ステップを追加**: `dist/index.js` と `dist/index.d.ts` が実際に存在するかを確認
2. **tarball 内容の検証ステップを追加**: `pnpm pack` で生成した tarball に `dist/` が含まれることを CI で保証し、同種の回帰を防止
3. **明示的な lint ステップを追加**: `--ignore-scripts` で `prepublishOnly` がスキップされるため、publish 前に明示的に lint を実行
4. **`pnpm publish --ignore-scripts` を追加**: publish 時に `prepare` が再実行されて dist が壊れる経路を遮断

### `pnpm-workspace.yaml`

`minimumReleaseAgeExclude` に `@book000/*` を追加し、内製パッケージが minimumReleaseAge ポリシー違反で CI が失敗する問題を修正。

## テスト結果

修正後のローカル検証:
```sh
$ pnpm pack --pack-destination /tmp/pack-verify
$ tar -tzf /tmp/pack-verify/*.tgz | wc -l
# → 171 (修正前: 3)

$ tar -tzf /tmp/pack-verify/*.tgz | grep 'dist/index'
# → package/dist/index.js
# → package/dist/index.d.ts
```

## 関連

- Closes #1576
- 同様の構成を持つ `@book000/node-utils` にも同じ修正の適用を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)