### PR TITLE
fix: TypeScript v6.0 向けに tsconfig.json を修正する

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": [
       "ESNext",
       "esnext.AsyncIterable"
@@ -29,8 +29,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "newLine": "LF"
   },
   "include": [


### PR DESCRIPTION
## 概要

TypeScript v6.0 マイグレーション時に追加された一時的な回避策を根本的に修正します。

## 変更内容

### `tsconfig.json` の修正

- **`moduleResolution` を `Node` から `bundler` に変更**
  - TypeScript 6.0 で `Node` は非推奨となった
  - `bundler` が推奨される代替案

- **`baseUrl` を削除**
  - プロジェクトで `paths` を使用していないため不要

- **`ignoreDeprecations: "6.0"` を削除**
  - TypeScript 7.0 では機能しなくなるため根本的に対応

## 動作確認

- `tsc --noEmit` によるビルドが正常に通ることを確認
- `pnpm build` によるフルビルドが正常に通ることを確認
- `pnpm lint` による Lint チェックがエラーなしであることを確認

Fixes #1611