### PR TITLE
fix(lint): unicorn/prefer-split-limit と不要な eslint-disable コメントを修正

### DIFF
--- a/src/pixiv.ts
+++ b/src/pixiv.ts
@@ -915,7 +915,7 @@ export default class Pixiv {
   public static parseQueryString(url: string) {
     let query = url
     if (url.includes('?')) {
-      query = url.split('?')[1]
+      query = url.split('?', 2)[1]
     }
 
     return qs.parse(query)

--- a/src/saving-responses/index.test.ts
+++ b/src/saving-responses/index.test.ts
@@ -594,7 +594,6 @@ describe('ResponseDatabase', () => {
     }
 
     it('should return default port when port is undefined', () => {
-      // eslint-disable-next-line unicorn/no-useless-undefined
       expect(testParsePort(undefined)).toBe(3306)
     })
 


### PR DESCRIPTION
Fixes #1617

## 概要

`@book000/eslint-config` のバージョンアップ（eslint-plugin-unicorn v65 系）により追加された新ルールへの違反を修正します。

## 変更内容

### `src/pixiv.ts` (line 918)

**ルール**: `unicorn/prefer-split-limit`

`String#split()` の結果が部分的にしか使用されない場合に `limit` 引数を要求するルールへの対応。

```diff
-      query = url.split(?)[1]
+      query = url.split(?, 2)[1]
```

`?` で分割した結果のうち `[1]`（2 番目の要素）のみを使用するため、`limit` は `2` が適切です。

### `src/saving-responses/index.test.ts` (line 597)

不要になった `// eslint-disable-next-line unicorn/no-useless-undefined` コメントを削除します。eslint-plugin-unicorn v65 系への更新により `unicorn/no-useless-undefined` ルールがこの箇所に適用されなくなったため、ディレクティブが未使用として警告されていました。

## 確認事項

- `pnpm lint`: ✅ エラー・警告なし
- `pnpm build`: ✅ 成功
- `pnpm test`: pixiv API テストは `PIXIV_REFRESH_TOKEN` 未設定による既存の失敗（CI 環境外では期待通り）。`src/saving-responses/index.test.ts` を含む 4 テストスイートはパス
