### PR TITLE
feat: add retry logic and tests for Retry-After header handling

### DIFF
--- a/src/pixiv.test.ts
+++ b/src/pixiv.test.ts
@@ -937,6 +937,27 @@ describe('Pixiv class coverage tests', () => {
       expect(setTimeoutSpy).toHaveBeenCalledTimes(2)
     })
 
+    it('should retry multiple times in a row and succeed once 429 stops', async () => {
+      const fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(Response.json({}, { status: 429 }))
+        .mockResolvedValueOnce(Response.json({}, { status: 429 }))
+        .mockResolvedValueOnce(Response.json({ ok: true }, { status: 200 }))
+
+      const client = new PixivHttpClient(
+        'https://example.com',
+        {},
+        { maxRetries: 3, waitMs: 1 }
+      )
+      const response = await client.get<{ ok: boolean }>('/test')
+
+      expect(response.status).toBe(200)
+      expect(response.data).toEqual({ ok: true })
+      // 429が2回続いた後に成功するため、計3回呼び出される
+      expect(fetchSpy).toHaveBeenCalledTimes(3)
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(2)
+    })
+
     it('should use the Retry-After header value (in seconds) as the wait time', async () => {
       const fetchSpy = jest
         .spyOn(globalThis, 'fetch')
@@ -954,6 +975,33 @@ describe('Pixiv class coverage tests', () => {
 
       // Retry-Afterヘッダーの値(秒)をミリ秒に変換した値で待機すること
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000)
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('should fall back to waitMs when the Retry-After header is not a numeric value', async () => {
+      const fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(
+          Response.json(
+            {},
+            {
+              status: 429,
+              // HTTP-date形式など、秒数として解釈できないRetry-After
+              headers: { 'Retry-After': 'Wed, 21 Oct 2026 07:28:00 GMT' },
+            }
+          )
+        )
+        .mockResolvedValueOnce(Response.json({ ok: true }, { status: 200 }))
+
+      const client = new PixivHttpClient(
+        'https://example.com',
+        {},
+        { maxRetries: 3, waitMs: 12_345 }
+      )
+      await client.get('/test')
+
+      // 秒数として解釈できないRetry-Afterの場合はwaitMsにフォールバックすること
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 12_345)
       expect(fetchSpy).toHaveBeenCalledTimes(2)
     })
 

--- a/src/pixiv.test.ts
+++ b/src/pixiv.test.ts
@@ -973,7 +973,7 @@ describe('Pixiv class coverage tests', () => {
       )
       await client.get('/test')
 
-      // Retry-Afterヘッダーの値(秒)をミリ秒に変換した値で待機すること
+      // Retry-After ヘッダーの値(秒)をミリ秒に変換した値で待機すること
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000)
       expect(fetchSpy).toHaveBeenCalledTimes(2)
     })
@@ -986,7 +986,7 @@ describe('Pixiv class coverage tests', () => {
             {},
             {
               status: 429,
-              // 秒数・HTTP-dateいずれの形式としても解釈できないRetry-After
+              // 秒数・HTTP-date いずれの形式としても解釈できない Retry-After
               headers: { 'Retry-After': 'invalid-value' },
             }
           )
@@ -1000,7 +1000,7 @@ describe('Pixiv class coverage tests', () => {
       )
       await client.get('/test')
 
-      // 秒数・HTTP-dateいずれとしても解釈できないRetry-Afterの場合はwaitMsにフォールバックすること
+      // 秒数・HTTP-date いずれとしても解釈できない Retry-After の場合は waitMs にフォールバックすること
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 12_345)
       expect(fetchSpy).toHaveBeenCalledTimes(2)
     })

--- a/src/pixiv.test.ts
+++ b/src/pixiv.test.ts
@@ -978,7 +978,7 @@ describe('Pixiv class coverage tests', () => {
       expect(fetchSpy).toHaveBeenCalledTimes(2)
     })
 
-    it('should fall back to waitMs when the Retry-After header is not a numeric value', async () => {
+    it('should fall back to waitMs when the Retry-After header is neither a number nor a valid date', async () => {
       const fetchSpy = jest
         .spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce(
@@ -986,8 +986,8 @@ describe('Pixiv class coverage tests', () => {
             {},
             {
               status: 429,
-              // HTTP-date形式など、秒数として解釈できないRetry-After
-              headers: { 'Retry-After': 'Wed, 21 Oct 2026 07:28:00 GMT' },
+              // 秒数・HTTP-dateいずれの形式としても解釈できないRetry-After
+              headers: { 'Retry-After': 'invalid-value' },
             }
           )
         )
@@ -1000,8 +1000,68 @@ describe('Pixiv class coverage tests', () => {
       )
       await client.get('/test')
 
-      // 秒数として解釈できないRetry-Afterの場合はwaitMsにフォールバックすること
+      // 秒数・HTTP-dateいずれとしても解釈できないRetry-Afterの場合はwaitMsにフォールバックすること
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 12_345)
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('should use the Retry-After header value when given as an HTTP-date', async () => {
+      const now = Date.UTC(2026, 0, 1, 0, 0, 0)
+      jest.spyOn(Date, 'now').mockReturnValue(now)
+
+      const fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(
+          Response.json(
+            {},
+            {
+              status: 429,
+              // 現在時刻 (2026-01-01T00:00:00Z) から7秒後のHTTP-date
+              headers: { 'Retry-After': 'Thu, 01 Jan 2026 00:00:07 GMT' },
+            }
+          )
+        )
+        .mockResolvedValueOnce(Response.json({ ok: true }, { status: 200 }))
+
+      const client = new PixivHttpClient(
+        'https://example.com',
+        {},
+        { maxRetries: 3, waitMs: 10_000 }
+      )
+      await client.get('/test')
+
+      // HTTP-dateと現在時刻の差分(ミリ秒)で待機すること
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 7000)
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not wait a negative time when the Retry-After HTTP-date is in the past', async () => {
+      const now = Date.UTC(2026, 0, 1, 0, 0, 10)
+      jest.spyOn(Date, 'now').mockReturnValue(now)
+
+      const fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(
+          Response.json(
+            {},
+            {
+              status: 429,
+              // 現在時刻 (2026-01-01T00:00:10Z) より過去のHTTP-date
+              headers: { 'Retry-After': 'Thu, 01 Jan 2026 00:00:00 GMT' },
+            }
+          )
+        )
+        .mockResolvedValueOnce(Response.json({ ok: true }, { status: 200 }))
+
+      const client = new PixivHttpClient(
+        'https://example.com',
+        {},
+        { maxRetries: 3, waitMs: 10_000 }
+      )
+      await client.get('/test')
+
+      // 過去日時の場合は待機時間を0にクランプすること
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0)
       expect(fetchSpy).toHaveBeenCalledTimes(2)
     })
 

--- a/src/pixiv.test.ts
+++ b/src/pixiv.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { BookmarkRestrict } from './options'
-import Pixiv from './pixiv'
+import Pixiv, { PixivHttpClient } from './pixiv'
 import { GetV1IllustDetailCheck } from './types/endpoints/v1/illust/detail'
 import { GetV1IllustRankingCheck } from './types/endpoints/v1/illust/ranking'
 import { GetV1IllustRecommendedCheck } from './types/endpoints/v1/illust/recommended'
@@ -881,6 +881,168 @@ describe('Pixiv class coverage tests', () => {
         // モックを元に戻す
         pixiv.http.get = originalHttpGet
         saveResponseSpy.mockRestore()
+      }
+    })
+  })
+
+  describe('rate limit retry', () => {
+    let setTimeoutSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      // setTimeoutをモック化し、実際には待機せずコールバックを即時実行する
+      setTimeoutSpy = jest
+        .spyOn(globalThis, 'setTimeout')
+        .mockImplementation((callback: () => void) => {
+          callback()
+          return 0 as unknown as NodeJS.Timeout
+        })
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should retry and return the response when a 429 is followed by a success', async () => {
+      const fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(Response.json({}, { status: 429 }))
+        .mockResolvedValueOnce(Response.json({ ok: true }, { status: 200 }))
+
+      const client = new PixivHttpClient('https://example.com', {})
+      const response = await client.get<{ ok: boolean }>('/test')
+
+      expect(response.status).toBe(200)
+      expect(response.data).toEqual({ ok: true })
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+      // デフォルトの待機時間 (10秒) で待機すること
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 10_000)
+    })
+
+    it('should throw an error when 429 persists beyond maxRetries', async () => {
+      const fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(Response.json({}, { status: 429 }))
+
+      const client = new PixivHttpClient(
+        'https://example.com',
+        {},
+        { maxRetries: 2, waitMs: 1 }
+      )
+
+      await expect(client.get('/test')).rejects.toThrow(
+        'Rate limit exceeded after maximum retries'
+      )
+      // 初回 + maxRetriesの2回 = 計3回呼び出される
+      expect(fetchSpy).toHaveBeenCalledTimes(3)
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('should use the Retry-After header value (in seconds) as the wait time', async () => {
+      const fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(
+          Response.json({}, { status: 429, headers: { 'Retry-After': '5' } })
+        )
+        .mockResolvedValueOnce(Response.json({ ok: true }, { status: 200 }))
+
+      const client = new PixivHttpClient(
+        'https://example.com',
+        {},
+        { maxRetries: 3, waitMs: 10_000 }
+      )
+      await client.get('/test')
+
+      // Retry-Afterヘッダーの値(秒)をミリ秒に変換した値で待機すること
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000)
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('should throw immediately without waiting when maxRetries is 0', async () => {
+      const fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(Response.json({}, { status: 429 }))
+
+      const client = new PixivHttpClient(
+        'https://example.com',
+        {},
+        { maxRetries: 0, waitMs: 10_000 }
+      )
+
+      await expect(client.get('/test')).rejects.toThrow(
+        'Rate limit exceeded after maximum retries'
+      )
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(setTimeoutSpy).not.toHaveBeenCalled()
+    })
+
+    it('should not retry when the response status is not 429', async () => {
+      const fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(Response.json({}, { status: 500 }))
+
+      const client = new PixivHttpClient('https://example.com', {})
+      const response = await client.get('/test')
+
+      expect(response.status).toBe(500)
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(setTimeoutSpy).not.toHaveBeenCalled()
+    })
+
+    it('should retry on post() as well', async () => {
+      const fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(Response.json({}, { status: 429 }))
+        .mockResolvedValueOnce(Response.json({ ok: true }, { status: 200 }))
+
+      const client = new PixivHttpClient(
+        'https://example.com',
+        {},
+        { maxRetries: 1, waitMs: 1 }
+      )
+      const response = await client.post<{ ok: boolean }>('/test', 'body')
+
+      expect(response.status).toBe(200)
+      expect(response.data).toEqual({ ok: true })
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('should propagate rateLimitRetryOptions from Pixiv.of to the http client', async () => {
+      const tokenFetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(
+          Response.json(
+            {
+              user: { id: 'test_user_id' },
+              response: {
+                access_token: 'test_access_token',
+                refresh_token: 'test_refresh_token',
+              },
+            },
+            { status: 200 }
+          )
+        )
+
+      let instance: Pixiv
+      try {
+        instance = await Pixiv.of('test_refresh_token', {
+          rateLimitRetryOptions: { maxRetries: 1, waitMs: 1 },
+        })
+      } finally {
+        tokenFetchSpy.mockRestore()
+      }
+
+      try {
+        const fetchSpy = jest
+          .spyOn(globalThis, 'fetch')
+          .mockResolvedValue(Response.json({}, { status: 429 }))
+
+        await expect(instance.http.get('/test')).rejects.toThrow(
+          'Rate limit exceeded after maximum retries'
+        )
+        // maxRetries: 1 のため、初回 + リトライ1回 = 計2回呼び出される
+        expect(fetchSpy).toHaveBeenCalledTimes(2)
+      } finally {
+        await instance.close()
       }
     })
   })

--- a/src/pixiv.ts
+++ b/src/pixiv.ts
@@ -164,10 +164,10 @@ function headersToRecord(headers: Headers): Record<string, string> {
 }
 
 /**
- * Retry-Afterヘッダーの値から待機時間（ミリ秒）を算出する。
+ * Retry-After ヘッダーの値から待機時間（ミリ秒）を算出する。
  * 秒数形式 (delay-seconds) と HTTP-date 形式の両方に対応し、
  * いずれの形式でも解釈できない場合はデフォルトの待機時間 (waitMs) を返す。
- * @param retryAfter - Retry-Afterヘッダーの値（未指定の場合は null）
+ * @param retryAfter - Retry-After ヘッダーの値（未指定の場合は null）
  * @param waitMs - デフォルトの待機時間（ミリ秒）
  * @returns 待機時間（ミリ秒）
  */
@@ -184,7 +184,7 @@ function getRetryAfterWaitTime(
     return Number.parseInt(retryAfter, 10) * 1000
   }
 
-  // HTTP-date形式 (例: "Wed, 21 Oct 2026 07:28:00 GMT")
+  // HTTP-date 形式 (例: "Wed, 21 Oct 2026 07:28:00 GMT")
   const retryDate = Date.parse(retryAfter)
   if (!Number.isNaN(retryDate)) {
     return Math.max(0, retryDate - Date.now())
@@ -196,7 +196,7 @@ function getRetryAfterWaitTime(
 export class PixivHttpClient {
   private readonly baseURL: string
   private readonly defaultHeaders: Record<string, string>
-  private readonly ratelimitRetryOptions: PixivRateLimitRetryOptions | null
+  private readonly rateLimitRetryOptions: PixivRateLimitRetryOptions | null
 
   constructor(
     baseURL: string,
@@ -205,7 +205,7 @@ export class PixivHttpClient {
   ) {
     this.baseURL = baseURL
     this.defaultHeaders = headers
-    this.ratelimitRetryOptions = rateLimitRetryOptions ?? null
+    this.rateLimitRetryOptions = rateLimitRetryOptions ?? null
   }
 
   async get<U>(
@@ -266,14 +266,20 @@ export class PixivHttpClient {
     url: string,
     options: RequestInit
   ): Promise<Response> {
-    const maxRetries = this.ratelimitRetryOptions?.maxRetries ?? 3
-    const waitMs = this.ratelimitRetryOptions?.waitMs ?? 10_000 // default 10 sec
+    // 負の値が渡された場合でもループが必ず1回以上実行されるよう0以上にクランプする
+    const maxRetries = Math.max(0, this.rateLimitRetryOptions?.maxRetries ?? 3)
+    // 負の値が渡された場合に setTimeout への待機時間が負値にならないよう0以上にクランプする
+    const waitMs = Math.max(0, this.rateLimitRetryOptions?.waitMs ?? 10_000) // default 10 sec
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       const response = await fetch(url, options)
       if (response.status !== 429) {
         return response
       }
+
+      // 429のレスポンスボディは使用しないため、コネクション解放のため破棄する
+      await response.body?.cancel()
+
       if (attempt < maxRetries) {
         const retryAfter = response.headers.get('Retry-After')
         const waitTime = getRetryAfterWaitTime(retryAfter, waitMs)
@@ -316,7 +322,7 @@ export default class Pixiv {
   readonly accessToken: string
   readonly refreshToken: string
   readonly responseDatabase: ResponseDatabase | null
-  readonly ratelimitRetryOptions: PixivRateLimitRetryOptions | null
+  readonly rateLimitRetryOptions: PixivRateLimitRetryOptions | null
   readonly http: PixivHttpClient
 
   /**
@@ -325,7 +331,8 @@ export default class Pixiv {
    * @param userId ユーザー ID
    * @param accessToken アクセストークン
    * @param refreshToken リフレッシュトークン
-   * @param pixivTsOptions Pixivts オプション
+   * @param responseDatabase レスポンス保存用データベース（使用しない場合は null）
+   * @param rateLimitRetryOptions 429エラー時のリトライ設定
    */
   private constructor(
     userId: string,
@@ -338,7 +345,7 @@ export default class Pixiv {
     this.accessToken = accessToken
     this.refreshToken = refreshToken
     this.responseDatabase = responseDatabase ?? null
-    this.ratelimitRetryOptions = rateLimitRetryOptions ?? null
+    this.rateLimitRetryOptions = rateLimitRetryOptions ?? null
 
     this.http = new PixivHttpClient(
       this.hosts,
@@ -350,7 +357,7 @@ export default class Pixiv {
         'Accept-Language': 'ja',
         Authorization: `Bearer ${this.accessToken}`,
       },
-      this.ratelimitRetryOptions
+      this.rateLimitRetryOptions
     )
   }
 

--- a/src/pixiv.ts
+++ b/src/pixiv.ts
@@ -134,6 +134,18 @@ interface PostRequestOptions<T> {
 
 type RequestOptions<T> = GetRequestOptions<T> | PostRequestOptions<T>
 
+export interface PixivRateLimitRetryOptions {
+  /**
+   * リクエストがレートリミットに達した場合の最大リトライ回数。
+   */
+  maxRetries: number
+
+  /**
+   * リクエストがレートリミットに達した場合のリトライまでの待機時間（ミリ秒）。
+   */
+  waitMs: number
+}
+
 export interface PixivApiResponse<T> {
   data: T
   status: number
@@ -154,10 +166,16 @@ function headersToRecord(headers: Headers): Record<string, string> {
 export class PixivHttpClient {
   private readonly baseURL: string
   private readonly defaultHeaders: Record<string, string>
+  private readonly ratelimitRetryOptions: PixivRateLimitRetryOptions | null
 
-  constructor(baseURL: string, headers: Record<string, string>) {
+  constructor(
+    baseURL: string,
+    headers: Record<string, string>,
+    rateLimitRetryOptions?: PixivRateLimitRetryOptions | null
+  ) {
     this.baseURL = baseURL
     this.defaultHeaders = headers
+    this.ratelimitRetryOptions = rateLimitRetryOptions ?? null
   }
 
   async get<U>(
@@ -169,7 +187,7 @@ export class PixivHttpClient {
       const queryString = qs.stringify(options.params)
       if (queryString) url += `?${queryString}`
     }
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       headers: this.defaultHeaders,
     })
     const contentType = response.headers.get('content-type') ?? ''
@@ -194,7 +212,7 @@ export class PixivHttpClient {
   ): Promise<PixivApiResponse<U>> {
     const url = `${this.baseURL}${path}`
     const headers = { ...this.defaultHeaders, ...options.headers }
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: 'POST',
       headers,
       body,
@@ -213,6 +231,31 @@ export class PixivHttpClient {
       responseUrl: response.url || undefined,
     }
   }
+
+  private async fetchWithRetry(
+    url: string,
+    options: RequestInit
+  ): Promise<Response> {
+    const maxRetries = this.ratelimitRetryOptions?.maxRetries ?? 3
+    const waitMs = this.ratelimitRetryOptions?.waitMs ?? 10_000 // default 10 sec
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const response = await fetch(url, options)
+      if (response.status !== 429) {
+        return response
+      }
+      if (attempt < maxRetries) {
+        const retryAfter = response.headers.get('Retry-After')
+        const waitTime = retryAfter
+          ? Number.parseInt(retryAfter, 10) * 1000
+          : waitMs
+
+        await new Promise((resolve) => setTimeout(resolve, waitTime))
+      }
+    }
+
+    throw new Error('Rate limit exceeded after maximum retries')
+  }
 }
 
 export interface PixivDebugOutputResponseOptions {
@@ -227,6 +270,7 @@ export interface PixivDebugOptions {
 
 export interface PixivTsOptions {
   debugOptions?: PixivDebugOptions
+  rateLimitRetryOptions?: PixivRateLimitRetryOptions
 }
 
 /**
@@ -244,6 +288,7 @@ export default class Pixiv {
   readonly accessToken: string
   readonly refreshToken: string
   readonly responseDatabase: ResponseDatabase | null
+  readonly ratelimitRetryOptions: PixivRateLimitRetryOptions | null
   readonly http: PixivHttpClient
 
   /**
@@ -258,21 +303,27 @@ export default class Pixiv {
     userId: string,
     accessToken: string,
     refreshToken: string,
-    responseDatabase?: ResponseDatabase | null
+    responseDatabase?: ResponseDatabase | null,
+    rateLimitRetryOptions?: PixivRateLimitRetryOptions
   ) {
     this.userId = userId
     this.accessToken = accessToken
     this.refreshToken = refreshToken
     this.responseDatabase = responseDatabase ?? null
+    this.ratelimitRetryOptions = rateLimitRetryOptions ?? null
 
-    this.http = new PixivHttpClient(this.hosts, {
-      Host: 'app-api.pixiv.net',
-      'App-OS': 'ios',
-      'App-OS-Version': '14.6',
-      'User-Agent': 'PixivIOSApp/7.13.3 (iOS 14.6; iPhone13,2)',
-      'Accept-Language': 'ja',
-      Authorization: `Bearer ${this.accessToken}`,
-    })
+    this.http = new PixivHttpClient(
+      this.hosts,
+      {
+        Host: 'app-api.pixiv.net',
+        'App-OS': 'ios',
+        'App-OS-Version': '14.6',
+        'User-Agent': 'PixivIOSApp/7.13.3 (iOS 14.6; iPhone13,2)',
+        'Accept-Language': 'ja',
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+      this.ratelimitRetryOptions
+    )
   }
 
   /**
@@ -347,7 +398,8 @@ export default class Pixiv {
       options.userId,
       options.accessToken,
       options.refreshToken,
-      responseDatabase
+      responseDatabase,
+      pixivTsOptions?.rateLimitRetryOptions
     )
   }
 

--- a/src/pixiv.ts
+++ b/src/pixiv.ts
@@ -245,10 +245,15 @@ export class PixivHttpClient {
         return response
       }
       if (attempt < maxRetries) {
+        // Retry-Afterヘッダーは秒数形式を想定する。値が存在しない、または
+        // HTTP-date形式などで秒数として解釈できない場合はwaitMsにフォールバックする
         const retryAfter = response.headers.get('Retry-After')
-        const waitTime = retryAfter
-          ? Number.parseInt(retryAfter, 10) * 1000
-          : waitMs
+        const retryAfterSeconds = retryAfter
+          ? Number.parseInt(retryAfter, 10)
+          : Number.NaN
+        const waitTime = Number.isNaN(retryAfterSeconds)
+          ? waitMs
+          : retryAfterSeconds * 1000
 
         await new Promise((resolve) => setTimeout(resolve, waitTime))
       }

--- a/src/pixiv.ts
+++ b/src/pixiv.ts
@@ -163,6 +163,36 @@ function headersToRecord(headers: Headers): Record<string, string> {
   return result
 }
 
+/**
+ * Retry-Afterヘッダーの値から待機時間（ミリ秒）を算出する。
+ * 秒数形式 (delay-seconds) と HTTP-date 形式の両方に対応し、
+ * いずれの形式でも解釈できない場合はデフォルトの待機時間 (waitMs) を返す。
+ * @param retryAfter - Retry-Afterヘッダーの値（未指定の場合は null）
+ * @param waitMs - デフォルトの待機時間（ミリ秒）
+ * @returns 待機時間（ミリ秒）
+ */
+function getRetryAfterWaitTime(
+  retryAfter: string | null,
+  waitMs: number
+): number {
+  if (!retryAfter) {
+    return waitMs
+  }
+
+  // 秒数形式 (delay-seconds)
+  if (/^\d+$/.test(retryAfter.trim())) {
+    return Number.parseInt(retryAfter, 10) * 1000
+  }
+
+  // HTTP-date形式 (例: "Wed, 21 Oct 2026 07:28:00 GMT")
+  const retryDate = Date.parse(retryAfter)
+  if (!Number.isNaN(retryDate)) {
+    return Math.max(0, retryDate - Date.now())
+  }
+
+  return waitMs
+}
+
 export class PixivHttpClient {
   private readonly baseURL: string
   private readonly defaultHeaders: Record<string, string>
@@ -245,15 +275,8 @@ export class PixivHttpClient {
         return response
       }
       if (attempt < maxRetries) {
-        // Retry-Afterヘッダーは秒数形式を想定する。値が存在しない、または
-        // HTTP-date形式などで秒数として解釈できない場合はwaitMsにフォールバックする
         const retryAfter = response.headers.get('Retry-After')
-        const retryAfterSeconds = retryAfter
-          ? Number.parseInt(retryAfter, 10)
-          : Number.NaN
-        const waitTime = Number.isNaN(retryAfterSeconds)
-          ? waitMs
-          : retryAfterSeconds * 1000
+        const waitTime = getRetryAfterWaitTime(retryAfter, waitMs)
 
         await new Promise((resolve) => setTimeout(resolve, waitTime))
       }


### PR DESCRIPTION
429エラーに対するリトライの仕組みを実装