### PR TITLE
fix: add missing fields and correct optional/required in type definitions

### DIFF
--- a/src/__snapshots__/pixiv.test.ts.snap
+++ b/src/__snapshots__/pixiv.test.ts.snap
@@ -87,7 +87,6 @@ exports[`pixiv illustDetail:103905962[manga] 1`] = `
   "page_count": 8,
   "request": null,
   "restrict": 0,
-  "restriction_attributes": [],
   "sanity_level": 2,
   "seasonal_effect_animation_urls": null,
   "series": null,
@@ -167,7 +166,6 @@ exports[`pixiv illustDetail:107565629[illust] 1`] = `
   "page_count": 1,
   "request": null,
   "restrict": 0,
-  "restriction_attributes": [],
   "sanity_level": 2,
   "seasonal_effect_animation_urls": null,
   "series": null,
@@ -339,7 +337,6 @@ exports[`pixiv illustSeries: illust_series_first_illust 1`] = `
   "page_count": 8,
   "request": null,
   "restrict": 0,
-  "restriction_attributes": [],
   "sanity_level": 2,
   "seasonal_effect_animation_urls": null,
   "series": {

--- a/src/__snapshots__/pixiv.test.ts.snap
+++ b/src/__snapshots__/pixiv.test.ts.snap
@@ -87,6 +87,7 @@ exports[`pixiv illustDetail:103905962[manga] 1`] = `
   "page_count": 8,
   "request": null,
   "restrict": 0,
+  "restriction_attributes": [],
   "sanity_level": 2,
   "seasonal_effect_animation_urls": null,
   "series": null,
@@ -166,6 +167,7 @@ exports[`pixiv illustDetail:107565629[illust] 1`] = `
   "page_count": 1,
   "request": null,
   "restrict": 0,
+  "restriction_attributes": [],
   "sanity_level": 2,
   "seasonal_effect_animation_urls": null,
   "series": null,
@@ -337,6 +339,7 @@ exports[`pixiv illustSeries: illust_series_first_illust 1`] = `
   "page_count": 8,
   "request": null,
   "restrict": 0,
+  "restriction_attributes": [],
   "sanity_level": 2,
   "seasonal_effect_animation_urls": null,
   "series": {

--- a/src/types/endpoints/v1/search/illust.ts
+++ b/src/types/endpoints/v1/search/illust.ts
@@ -108,8 +108,10 @@ export interface GetV1SearchIllustResponse {
 
   /**
    * Whether AI-generated works are shown in the search results
+   *
+   * Not consistently present in all API responses.
    */
-  show_ai: boolean
+  show_ai?: boolean
 }
 
 export class GetV1SearchIllustCheck extends BaseMultipleCheck<
@@ -151,7 +153,8 @@ export class GetV1SearchIllustCheck extends BaseMultipleCheck<
         data.next_url === null ||
         (typeof data.next_url === 'string' && data.next_url.length > 0),
       search_span_limit: (data) => typeof data.search_span_limit === 'number',
-      show_ai: (data) => typeof data.show_ai === 'boolean',
+      show_ai: (data) =>
+        data.show_ai === undefined || typeof data.show_ai === 'boolean',
     }
   }
 }

--- a/src/types/endpoints/v1/search/illust.ts
+++ b/src/types/endpoints/v1/search/illust.ts
@@ -105,6 +105,11 @@ export interface GetV1SearchIllustResponse {
    * @beta
    */
   search_span_limit: number
+
+  /**
+   * Whether AI-generated works are shown in the search results
+   */
+  show_ai: boolean
 }
 
 export class GetV1SearchIllustCheck extends BaseMultipleCheck<
@@ -146,6 +151,7 @@ export class GetV1SearchIllustCheck extends BaseMultipleCheck<
         data.next_url === null ||
         (typeof data.next_url === 'string' && data.next_url.length > 0),
       search_span_limit: (data) => typeof data.search_span_limit === 'number',
+      show_ai: (data) => typeof data.show_ai === 'boolean',
     }
   }
 }

--- a/src/types/endpoints/v1/search/novel.ts
+++ b/src/types/endpoints/v1/search/novel.ts
@@ -105,7 +105,7 @@ export interface GetV1SearchNovelResponse {
   /**
    * Whether AI-generated works are shown in the search results
    *
-   * Not present in all API responses (e.g. absent from novel search).
+   * Not consistently present in all API responses.
    */
   show_ai?: boolean
 }

--- a/src/types/endpoints/v1/search/novel.ts
+++ b/src/types/endpoints/v1/search/novel.ts
@@ -104,8 +104,10 @@ export interface GetV1SearchNovelResponse {
 
   /**
    * Whether AI-generated works are shown in the search results
+   *
+   * Not present in all API responses (e.g. absent from novel search).
    */
-  show_ai: boolean
+  show_ai?: boolean
 }
 
 export class GetV1SearchNovelCheck extends BaseMultipleCheck<
@@ -147,7 +149,8 @@ export class GetV1SearchNovelCheck extends BaseMultipleCheck<
         data.next_url === null ||
         (typeof data.next_url === 'string' && data.next_url.length > 0),
       search_span_limit: (data) => typeof data.search_span_limit === 'number',
-      show_ai: (data) => typeof data.show_ai === 'boolean',
+      show_ai: (data) =>
+        data.show_ai === undefined || typeof data.show_ai === 'boolean',
     }
   }
 }

--- a/src/types/endpoints/v1/search/novel.ts
+++ b/src/types/endpoints/v1/search/novel.ts
@@ -101,6 +101,11 @@ export interface GetV1SearchNovelResponse {
    * @beta
    */
   search_span_limit: number
+
+  /**
+   * Whether AI-generated works are shown in the search results
+   */
+  show_ai: boolean
 }
 
 export class GetV1SearchNovelCheck extends BaseMultipleCheck<
@@ -142,6 +147,7 @@ export class GetV1SearchNovelCheck extends BaseMultipleCheck<
         data.next_url === null ||
         (typeof data.next_url === 'string' && data.next_url.length > 0),
       search_span_limit: (data) => typeof data.search_span_limit === 'number',
+      show_ai: (data) => typeof data.show_ai === 'boolean',
     }
   }
 }

--- a/src/types/pixiv-common.ts
+++ b/src/types/pixiv-common.ts
@@ -66,6 +66,14 @@ export interface PixivUser {
 
   /** Whether this user has blocked access */
   is_access_blocking_user?: boolean
+
+  /**
+   * Whether the user accepts work requests
+   *
+   * Returned by following/follower endpoints. Indicates whether the user's
+   * request acceptance setting is enabled.
+   */
+  is_accept_request?: boolean
 }
 
 export class PixivUserCheck extends BaseSimpleCheck<PixivUser> {
@@ -84,6 +92,9 @@ export class PixivUserCheck extends BaseSimpleCheck<PixivUser> {
       is_access_blocking_user: (data) =>
         data.is_access_blocking_user === undefined ||
         typeof data.is_access_blocking_user === 'boolean',
+      is_accept_request: (data) =>
+        data.is_accept_request === undefined ||
+        typeof data.is_accept_request === 'boolean',
     }
   }
 }

--- a/src/types/pixiv-illust.ts
+++ b/src/types/pixiv-illust.ts
@@ -15,10 +15,11 @@ export interface MetaSinglePage {
   /**
    * Original image URL
    *
-   * Not present for manga (multi-page) works, since {@link PixivIllustItem.meta_single_page}
-   * is an empty object for those works.
+   * Always present when {@link PixivIllustItem.meta_single_page} is a {@link MetaSinglePage}
+   * (i.e. for single-page works). For manga (multi-page works), `meta_single_page` is typed as
+   * `Record<string, never>` (empty object) and this field is never accessed.
    */
-  original_image_url?: string
+  original_image_url: string
 }
 
 /** Multi-illust details */
@@ -252,6 +253,7 @@ export class PixivIllustItemCheck extends BaseSimpleCheck<PixivIllustItem> {
       meta_single_page: (data: PixivIllustItem): boolean =>
         typeof data.meta_single_page === 'object' &&
         (isEmptyObject(data.meta_single_page) ||
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           data.meta_single_page.original_image_url !== undefined),
       meta_pages: (data: PixivIllustItem): boolean =>
         typeof data.meta_pages === 'object' &&

--- a/src/types/pixiv-illust.ts
+++ b/src/types/pixiv-illust.ts
@@ -12,8 +12,13 @@ import {
 
 /** Single-illust details */
 export interface MetaSinglePage {
-  /** Original image URL */
-  original_image_url: string
+  /**
+   * Original image URL
+   *
+   * Not present for manga (multi-page) works, since {@link PixivIllustItem.meta_single_page}
+   * is an empty object for those works.
+   */
+  original_image_url?: string
 }
 
 /** Multi-illust details */
@@ -199,6 +204,13 @@ export interface PixivIllustItem {
    * @beta
    */
   comment_access_control?: number
+
+  /**
+   * Restriction attributes
+   *
+   * Purpose unknown. Defaults to an empty array.
+   */
+  restriction_attributes: string[]
 }
 
 export class PixivIllustItemCheck extends BaseSimpleCheck<PixivIllustItem> {
@@ -240,7 +252,6 @@ export class PixivIllustItemCheck extends BaseSimpleCheck<PixivIllustItem> {
       meta_single_page: (data: PixivIllustItem): boolean =>
         typeof data.meta_single_page === 'object' &&
         (isEmptyObject(data.meta_single_page) ||
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           data.meta_single_page.original_image_url !== undefined),
       meta_pages: (data: PixivIllustItem): boolean =>
         typeof data.meta_pages === 'object' &&
@@ -267,6 +278,9 @@ export class PixivIllustItemCheck extends BaseSimpleCheck<PixivIllustItem> {
         typeof data.illust_ai_type === 'number',
       illust_book_style: (data: PixivIllustItem): boolean =>
         typeof data.illust_book_style === 'number',
+      restriction_attributes: (data: PixivIllustItem): boolean =>
+        Array.isArray(data.restriction_attributes) &&
+        data.restriction_attributes.every((attr) => typeof attr === 'string'),
     }
   }
 }

--- a/src/types/pixiv-illust.ts
+++ b/src/types/pixiv-illust.ts
@@ -208,9 +208,9 @@ export interface PixivIllustItem {
   /**
    * Restriction attributes
    *
-   * Purpose unknown. Defaults to an empty array.
+   * Purpose unknown. Not always present in API responses.
    */
-  restriction_attributes: string[]
+  restriction_attributes?: string[]
 }
 
 export class PixivIllustItemCheck extends BaseSimpleCheck<PixivIllustItem> {
@@ -279,8 +279,11 @@ export class PixivIllustItemCheck extends BaseSimpleCheck<PixivIllustItem> {
       illust_book_style: (data: PixivIllustItem): boolean =>
         typeof data.illust_book_style === 'number',
       restriction_attributes: (data: PixivIllustItem): boolean =>
-        Array.isArray(data.restriction_attributes) &&
-        data.restriction_attributes.every((attr) => typeof attr === 'string'),
+        data.restriction_attributes === undefined ||
+        (Array.isArray(data.restriction_attributes) &&
+          data.restriction_attributes.every(
+            (attr) => typeof attr === 'string'
+          )),
     }
   }
 }

--- a/src/types/pixiv-novel.ts
+++ b/src/types/pixiv-novel.ts
@@ -148,6 +148,15 @@ export interface PixivNovelItem {
    * @see https://github.com/ArkoClub/async-pixiv/blob/fa45c81093a5c6f4eabfcc942915fc479e42174f/src/async_pixiv/model/other.py#L40-L48
    */
   novel_ai_type: number
+
+  /**
+   * Comment visibility control?
+   *
+   * Already defined in {@link PixivIllustItem} for illusts; added here for parity.
+   *
+   * @beta
+   */
+  comment_access_control?: number
 }
 
 export class PixivNovelItemCheck extends BaseSimpleCheck<PixivNovelItem> {
@@ -185,6 +194,9 @@ export class PixivNovelItemCheck extends BaseSimpleCheck<PixivNovelItem> {
       is_mypixiv_only: (data) => typeof data.is_mypixiv_only === 'boolean',
       is_x_restricted: (data) => typeof data.is_x_restricted === 'boolean',
       novel_ai_type: (data) => typeof data.novel_ai_type === 'number',
+      comment_access_control: (data) =>
+        data.comment_access_control === undefined ||
+        typeof data.comment_access_control === 'number',
     }
   }
 }

--- a/src/types/pixiv-user.ts
+++ b/src/types/pixiv-user.ts
@@ -149,8 +149,8 @@ export interface PixivUserProfile {
   /**
    * Pawoo account URL
    *
-   * - Only present if linked with a Pawoo account and "Show link to Pawoo account" is checked.
-   * - Null if not linked or not displayed
+   * - Null if not linked with a Pawoo account, or if "Show link to Pawoo account" is unchecked
+   * - Non-null only when a Pawoo account is linked and the display setting is enabled
    */
   pawoo_url: string | null
 

--- a/src/types/pixiv-user.ts
+++ b/src/types/pixiv-user.ts
@@ -139,16 +139,20 @@ export interface PixivUserProfile {
    */
   twitter_account: string
 
-  /** Twitter account URL */
-  twitter_url: string
+  /**
+   * Twitter account URL
+   *
+   * - Null if no Twitter account is linked
+   */
+  twitter_url: string | null
 
   /**
    * Pawoo account URL
    *
    * - Only present if linked with a Pawoo account and "Show link to Pawoo account" is checked.
-   * - Empty string if not linked or not displayed
+   * - Null if not linked or not displayed
    */
-  pawoo_url: string
+  pawoo_url: string | null
 
   /** Whether it is a premium account */
   is_premium: boolean
@@ -210,10 +214,16 @@ export class PixivUserProfileCheck extends BaseSimpleCheck<PixivUserProfile> {
         typeof data.total_novel_series === 'number' &&
         data.total_novel_series >= 0,
       background_image_url: (data) =>
-        typeof data.background_image_url === 'string',
+        typeof data.background_image_url === 'string' ||
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        data.background_image_url === null,
       twitter_account: (data) => typeof data.twitter_account === 'string',
-      twitter_url: (data) => typeof data.twitter_url === 'string',
-      pawoo_url: (data) => typeof data.pawoo_url === 'string',
+      twitter_url: (data) =>
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        typeof data.twitter_url === 'string' || data.twitter_url === null,
+      pawoo_url: (data) =>
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        typeof data.pawoo_url === 'string' || data.pawoo_url === null,
       is_premium: (data) => typeof data.is_premium === 'boolean',
       is_using_custom_profile_image: (data) =>
         typeof data.is_using_custom_profile_image === 'boolean',


### PR DESCRIPTION
## Overview

Adds missing fields to common type models and corrects incorrect optional/required definitions in response types.

## Changes

### Missing field additions (type completeness)

- **`PixivUser`**: Added `is_accept_request?: boolean` — returned by following/follower endpoints, indicates whether the user accepts work requests
- **`PixivIllustItem`**: Added `restriction_attributes?: string[]` — not consistently present in API responses
- **`PixivNovelItem`**: Added `comment_access_control?: number` — parity with the same field already defined in `PixivIllustItem`
- **`GetV1SearchIllustResponse` / `GetV1SearchNovelResponse`**: Added `show_ai?: boolean` — not consistently present in all API responses

### Optional/required corrections (type accuracy)

- **`PixivUserProfile.twitter_url`**: `string` → `string | null` — `null` is returned for users without a linked Twitter account
- **`PixivUserProfile.pawoo_url`**: `string` → `string | null` — `null` is returned for users without a linked Pawoo account
- **`MetaSinglePage.original_image_url`**: Updated JSDoc to clarify this field is always present for single-page works; the union type `MetaSinglePage | Record<string, never>` already handles the manga (empty object) case, so the type signature remains `string`

### Bug fix (incidental)

- **`PixivUserProfileCheck.background_image_url`**: The check incorrectly rejected `null` despite the type declaring `string | null`; corrected to allow `null`

### Check class updates

- Added or updated validation logic in the corresponding `Check` classes for all fields above

## Verification

- `pnpm lint`: passes
- All tests: 118/118 passed