### PR TITLE
fix: strip Markdown code from PR body before language ratio check

### DIFF
--- a/scripts/check-pr-language.mjs
+++ b/scripts/check-pr-language.mjs
@@ -18,10 +18,10 @@ const LATIN_PATTERN = /[A-Za-z0-9]/gu
  * @returns Text with code blocks and inline code removed
  */
 function stripMarkdownCode(text) {
-  // Remove fenced code blocks first (``` ... ```)
-  let stripped = text.replace(/```[\s\S]*?```/g, '')
-  // Remove inline code (` ... `) — single backtick, no newline inside
-  stripped = stripped.replace(/`[^`\n]*`/g, '')
+  // Remove fenced code blocks (3 or more backticks, per CommonMark spec)
+  let stripped = text.replace(/`{3,}[\s\S]*?`{3,}/g, '')
+  // Remove inline code (1 or more backticks as delimiter, no newline inside)
+  stripped = stripped.replace(/`+[^`\n]*`+/g, '')
   return stripped
 }
 

--- a/scripts/check-pr-language.mjs
+++ b/scripts/check-pr-language.mjs
@@ -19,9 +19,9 @@ const LATIN_PATTERN = /[A-Za-z0-9]/gu
  */
 function stripMarkdownCode(text) {
   // Remove fenced code blocks (3 or more backticks, per CommonMark spec)
-  let stripped = text.replace(/`{3,}[\s\S]*?`{3,}/g, '')
+  let stripped = text.replaceAll(/`{3,}[\s\S]*?`{3,}/g, '')
   // Remove inline code (1 or more backticks as delimiter, no newline inside)
-  stripped = stripped.replace(/`+[^`\n]*`+/g, '')
+  stripped = stripped.replaceAll(/`+[^`\n]*`+/g, '')
   return stripped
 }
 

--- a/scripts/check-pr-language.mjs
+++ b/scripts/check-pr-language.mjs
@@ -11,6 +11,21 @@ const JAPANESE_PATTERN = /[぀-ゟ゠-ヿ㐀-䶿一-鿿]/gu
 const LATIN_PATTERN = /[A-Za-z0-9]/gu
 
 /**
+ * Strips Markdown fenced code blocks (``` ... ```) and inline code (` ... `)
+ * from the given text so that code snippets do not dilute the language ratio.
+ *
+ * @param text - Markdown text to strip
+ * @returns Text with code blocks and inline code removed
+ */
+function stripMarkdownCode(text) {
+  // Remove fenced code blocks first (``` ... ```)
+  let stripped = text.replace(/```[\s\S]*?```/g, '')
+  // Remove inline code (` ... `) — single backtick, no newline inside
+  stripped = stripped.replace(/`[^`\n]*`/g, '')
+  return stripped
+}
+
+/**
  * Calculates the ratio of Japanese characters to the total number of
  * Japanese and Latin alphanumeric characters in the given text.
  *
@@ -33,6 +48,8 @@ function calculateJapaneseRatio(text) {
 /**
  * Checks the PR title and body against {@link JAPANESE_RATIO_THRESHOLD}.
  *
+ * Code blocks and inline code are stripped from the body before checking so
+ * that English identifiers inside code snippets do not dilute the ratio.
  * The body is skipped if it is empty (or only whitespace).
  *
  * @param title - PR title
@@ -52,7 +69,8 @@ function checkPullRequestLanguage(title, body) {
 
   const trimmedBody = (body ?? '').trim()
   if (trimmedBody.length > 0) {
-    const bodyRatio = calculateJapaneseRatio(trimmedBody)
+    const strippedBody = stripMarkdownCode(trimmedBody)
+    const bodyRatio = calculateJapaneseRatio(strippedBody)
     if (bodyRatio >= JAPANESE_RATIO_THRESHOLD) {
       failures.push(
         `PR body appears to be mostly Japanese (Japanese ratio: ${bodyRatio.toFixed(2)}). Please write the PR body in English.`


### PR DESCRIPTION
## Summary

The `check-pr-language.mjs` script was not failing for PR bodies written in Japanese when those bodies contained inline code snippets (e.g. file paths, backtick-quoted identifiers). The English characters inside code snippets diluted the Japanese ratio below the 0.8 threshold, causing the check to pass incorrectly.

## Root cause

A Japanese prose body containing code references measured a Japanese ratio of 0.59 — below the 0.8 threshold — because the Latin characters inside inline code (e.g. `.github/workflows/nodejs-ci.yml`, `body-includes`) were counted together with the prose characters.

## Fix

Added a `stripMarkdownCode` function that removes fenced code blocks (```...```) and inline code (````...````) from the body before calculating the ratio. After stripping, the same Japanese body measures 0.85, correctly triggering a failure.

## Verification

| Body | Ratio before strip | Ratio after strip | Result |
|---|---|---|---|
| Japanese prose + code refs | 0.59 | 0.85 | ❌ fail (correct) |
| English prose + code refs | 0.00 | 0.00 | ✅ pass (correct) |