### PR TITLE
fix: set version from release tag when deploying API docs

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -2,10 +2,8 @@ name: Deploy
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - master
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -44,6 +42,12 @@ jobs:
 
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile --prefer-frozen-lockfile
+
+      - name: 🏷 Set version from latest git tag
+        run: |
+          VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
+          echo "Using version: $VERSION"
+          (cd packages/core && npm version --no-git-tag-version "$VERSION")
 
       - name: 📄 Generate API documentation
         run: pnpm --filter @book000/pixivts run generate-docs

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # For release events, check out the exact tagged commit so that the
+          # generated docs match the released code. For workflow_dispatch there
+          # is no release tag, so fall back to the default branch HEAD.
+          ref: ${{ github.event.release.tag_name || github.ref }}
 
       - name: 🏗 Setup node
         uses: actions/setup-node@v6
@@ -43,9 +47,17 @@ jobs:
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile --prefer-frozen-lockfile
 
-      - name: 🏷 Set version from latest git tag
+      - name: 🏷 Set version from release tag
         run: |
-          VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
+          # For release events, use the tag name from the event payload directly
+          # to avoid any reliance on git history ordering.
+          # For workflow_dispatch, fall back to the latest git tag.
+          TAG="${{ github.event.release.tag_name }}"
+          if [[ -n "$TAG" ]]; then
+            VERSION="${TAG#v}"
+          else
+            VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
+          fi
           echo "Using version: $VERSION"
           (cd packages/core && npm version --no-git-tag-version "$VERSION")
 

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -63,7 +63,12 @@ jobs:
             VERSION="${RAW#v}"
           fi
           echo "Using version: $VERSION"
-          (cd packages/core && npm version --no-git-tag-version "$VERSION")
+          # Skip npm version when VERSION is 0.0.0: package.json is already at
+          # 0.0.0 in the repository and npm errors with "Version not changed"
+          # when setting the same version.
+          if [[ "$VERSION" != "0.0.0" ]]; then
+            (cd packages/core && npm version --no-git-tag-version "$VERSION")
+          fi
 
       - name: 📄 Generate API documentation
         run: pnpm --filter @book000/pixivts run generate-docs

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -56,7 +56,11 @@ jobs:
           if [[ -n "$TAG" ]]; then
             VERSION="${TAG#v}"
           else
-            VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
+            # Avoid piping through sed: if git describe fails, sed still exits 0
+            # and the || fallback never runs, leaving VERSION empty.
+            # Capture the raw tag with || on the subshell, then strip the v prefix.
+            RAW=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+            VERSION="${RAW#v}"
           fi
           echo "Using version: $VERSION"
           (cd packages/core && npm version --no-git-tag-version "$VERSION")


### PR DESCRIPTION
## Summary

TypeDoc always showed `v0.0.0` at https://book000.github.io/pixivts/ because `package.json` always contains `version: 0.0.0` in the repository — the `release.yml` bumps the version in CI but does not commit it back.

There were also two race/mismatch conditions in the original approach:

1. **Race condition**: both `release.yml` and `pages-deploy.yml` triggered on the same `push` event, so `git describe --tags` could run before the release workflow created the new tag, picking up the previous tag.
2. **Content/version mismatch**: even with a `release`-based trigger, the default checkout uses `GITHUB_SHA` (default branch HEAD), not the tagged commit. A commit pushed to master after the tag is created would cause the docs to be built from newer code while still showing the release version.

## Changes

- Switch trigger from `push: branches: [master]` to `release: types: [published]`
  — docs are deployed only after the release workflow finishes, eliminating the race condition
- Add `ref: github.event.release.tag_name` to the checkout step so docs are built from the exact commit the release tag points to (falls back to `github.ref` for `workflow_dispatch`)
- Add a version step that reads `github.event.release.tag_name` directly from the event payload instead of `git describe`, then applies it to `packages/core/package.json` before generating docs (falls back to `git describe` for `workflow_dispatch`)

## Behavior

| Before | After |
|---|---|
| Triggered on every push (races with release workflow) | Triggered only after GitHub Release is published |
| Checked out default branch HEAD | Checks out the exact tagged commit |
| Always showed `v0.0.0` | Shows the release version (e.g., `0.56.2`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)