### PR TITLE
feat(core): add maxBookmarkId to UserBookmarksNovelParams

### DIFF
--- a/packages/core/src/resources/users.ts
+++ b/packages/core/src/resources/users.ts
@@ -52,6 +52,8 @@ export interface UserBookmarksNovelParams {
   filter?: OSFilter
   /** Limit results to bookmarks with this tag. */
   tag?: string
+  /** Fetch bookmarks older than this bookmark ID (cursor-based pagination). */
+  maxBookmarkId?: number
   /** Zero-based offset for pagination. */
   offset?: number
 }
@@ -161,6 +163,7 @@ export class UserBookmarksResource {
           restrict: params.restrict ?? 'public',
           filter: params.filter ?? 'for_ios',
           tag: params.tag,
+          maxBookmarkId: params.maxBookmarkId,
           offset: params.offset,
         })
       ),

--- a/packages/core/tests/client.test.ts
+++ b/packages/core/tests/client.test.ts
@@ -404,6 +404,48 @@ describe('users.following()', () => {
   })
 })
 
+describe('users.bookmarks.novels()', () => {
+  it('returns Ok with bookmarked novels', async () => {
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get('https://app-api.pixiv.net/v1/user/bookmarks/novel', () =>
+        HttpResponse.json({ novels: [NOVEL], next_url: null })
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.users.bookmarks.novels({ userId: 42 })
+    expect(result.isOk).toBe(true)
+    if (result.isOk) {
+      expect(result.value.novels).toHaveLength(1)
+      expect(result.value.novels[0].id).toBe(100)
+    }
+  })
+
+  it('sends max_bookmark_id when maxBookmarkId is specified', async () => {
+    let capturedUrl: string | undefined
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get(
+        'https://app-api.pixiv.net/v1/user/bookmarks/novel',
+        ({ request }) => {
+          capturedUrl = request.url
+          return HttpResponse.json({ novels: [NOVEL], next_url: null })
+        }
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    await client.users.bookmarks.novels({ userId: 42, maxBookmarkId: 9999 })
+    expect(capturedUrl).toBeDefined()
+    if (capturedUrl === undefined) return
+    const params = new URL(capturedUrl).searchParams
+    expect(params.get('max_bookmark_id')).toBe('9999')
+  })
+})
+
 describe('ugoira.metadata()', () => {
   it('returns Ok with ugoira frames', async () => {
     server.use(


### PR DESCRIPTION
## Summary

Adds `maxBookmarkId` to `UserBookmarksNovelParams` for cursor-based pagination of `/v1/user/bookmarks/novel`.

The `max_bookmark_id` query parameter is accepted by the endpoint and was present in the legacy `userBookmarksNovel()` implementation, but was inadvertently dropped from `UserBookmarksNovelParams` during the architecture rewrite in #1643. `UserBookmarksIllustParams` was not affected.

## Changes

- `packages/core/src/resources/users.ts`: Added `maxBookmarkId?: number` to `UserBookmarksNovelParams` and passed it through `buildParams` in the `novels()` method of `UserBookmarksResource`
- `packages/core/tests/client.test.ts`: Added tests for `users.bookmarks.novels()` — basic response and `max_bookmark_id` query parameter propagation

## Evidence

Cross-library research confirms `max_bookmark_id` is a valid parameter for `/v1/user/bookmarks/novel`:

| Library | novels `max_bookmark_id` | illusts `max_bookmark_id` |
|---|---|---|
| upbit/pixivpy (⭐ 2036) | ✅ | ✅ |
| alphasp/pixiv-api-client (⭐ 154) | ⚠️ implicit via options spread | ⚠️ same |
| Legacy `src/pixiv.ts` (this repo, pre-#1643) | ✅ | ✅ |

Closes #1660