### PR TITLE
feat: post-redesign UX improvements

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Upload Pages-artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: docs
+          path: docs-out
 
   deploy:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -129,5 +129,5 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
-docs
+docs-out
 packages/*/dist

--- a/README.md
+++ b/README.md
@@ -27,93 +27,27 @@ This is NOT a fork of [@ibaraki-douji/pixivts](https://www.npmjs.com/package/@ib
 npm install @book000/pixivts
 ```
 
-### Authentication
-
 ```typescript
 import { PixivClient } from '@book000/pixivts'
 
 const client = await PixivClient.of(process.env.PIXIV_REFRESH_TOKEN!)
-console.log(client.userId) // number — authenticated user ID
-```
 
-### Fetching a single work
-
-Every method returns `Result<T, PixivError>`. Check `result.isOk` to narrow the
-type before accessing `.value` or `.error`.
-
-```typescript
 const result = await client.illusts.detail({ illustId: 12345 })
 if (result.isOk) {
   console.log(result.value.illust.title)
-} else {
-  console.error(result.error)
 }
 ```
 
-### Pagination — iterating items
+## 📖 Documentation
 
-Use `.items()` to lazily stream every item across all pages:
-
-```typescript
-for await (const illust of client.illusts.search({ word: 'hatsune miku' }).items()) {
-  console.log(illust.id, illust.title)
-}
-
-for await (const novel of client.users.bookmarks.novels({ userId: client.userId }).items()) {
-  console.log(novel.title)
-}
-```
-
-Use `.pages()` when you need the raw page object (e.g. to access `next_url`):
-
-```typescript
-for await (const page of client.illusts.search({ word: 'hatsune miku' }).pages()) {
-  console.log(`page has ${page.illusts.length} illusts`)
-}
-```
-
-### Enum-like option constants
-
-All option types ship both as `const` objects and as string literal types, so
-you can use the enum-like syntax or a plain string — whichever you prefer:
-
-```typescript
-import { BookmarkRestrict, RankingMode } from '@book000/pixivts'
-
-// Enum-like (shows up in IDE autocomplete)
-await client.illusts.bookmarkAdd({ illustId: 123, restrict: BookmarkRestrict.PUBLIC })
-await client.illusts.ranking({ mode: RankingMode.WEEK })
-
-// Plain string — also valid
-await client.illusts.bookmarkAdd({ illustId: 123, restrict: 'public' })
-```
-
-### Resuming pagination from a saved cursor
-
-Use `parseNextUrl` to extract typed cursor params from `next_url` so you can
-resume from a saved position across restarts:
-
-```typescript
-import { parseNextUrl } from '@book000/pixivts'
-
-const page = await client.users.bookmarks.illusts({ userId: client.userId })
-if (page.isOk && page.value.next_url) {
-  const cursor = parseNextUrl(page.value.next_url)
-  // Persist cursor.maxBookmarkId, then next time:
-  const resumed = await client.users.bookmarks.illusts({
-    userId: client.userId,
-    maxBookmarkId: cursor.maxBookmarkId,
-  })
-}
-```
+- **[Getting Started](docs/getting-started.md)** — authentication, Result type, error handling
+- **[Pagination](docs/pagination.md)** — `.items()` / `.pages()`, cursor-based resume
+- **[Option Constants](docs/options.md)** — enum-like `BookmarkRestrict.PUBLIC` etc.
+- **[API Reference](https://book000.github.io/pixivts/)** — full TypeDoc reference
 
 ## 🔄 Migration from 0.55.1 and earlier
 
 If you are migrating from the previous version of `@book000/pixivts`, see [MIGRATION.md](MIGRATION.md).
-
-## 📚 API Documentation
-
-Full API reference: <https://book000.github.io/pixivts/>
 
 ## 📑 License
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,9 @@ if (result.isOk) {
 - **[Getting Started](docs/getting-started.md)** — authentication, Result type, error handling
 - **[Pagination](docs/pagination.md)** — `.items()` / `.pages()`, cursor-based resume
 - **[Option Constants](docs/options.md)** — enum-like `BookmarkRestrict.PUBLIC` etc.
+- **[MySQL Recorder](docs/db-mysql.md)** — `@book000/pixivts-db-mysql` setup and query helpers
+- **[Migration Guide](docs/migration.md)** — migrating from ≤ 0.55.1 to ≥ 0.56.2
 - **[API Reference](https://book000.github.io/pixivts/)** — full TypeDoc reference
-
-## 🔄 Migration from 0.55.1 and earlier
-
-If you are migrating from the previous version of `@book000/pixivts`, see [MIGRATION.md](MIGRATION.md).
 
 ## 📑 License
 

--- a/README.md
+++ b/README.md
@@ -27,21 +27,83 @@ This is NOT a fork of [@ibaraki-douji/pixivts](https://www.npmjs.com/package/@ib
 npm install @book000/pixivts
 ```
 
+### Authentication
+
 ```typescript
 import { PixivClient } from '@book000/pixivts'
 
 const client = await PixivClient.of(process.env.PIXIV_REFRESH_TOKEN!)
+console.log(client.userId) // number — authenticated user ID
+```
 
+### Fetching a single work
+
+Every method returns `Result<T, PixivError>`. Check `result.isOk` to narrow the
+type before accessing `.value` or `.error`.
+
+```typescript
 const result = await client.illusts.detail({ illustId: 12345 })
 if (result.isOk) {
   console.log(result.value.illust.title)
+} else {
+  console.error(result.error)
+}
+```
+
+### Pagination — iterating items
+
+Use `.items()` to lazily stream every item across all pages:
+
+```typescript
+for await (const illust of client.illusts.search({ word: 'hatsune miku' }).items()) {
+  console.log(illust.id, illust.title)
 }
 
-// Iterate over all pages
+for await (const novel of client.users.bookmarks.novels({ userId: client.userId }).items()) {
+  console.log(novel.title)
+}
+```
+
+Use `.pages()` when you need the raw page object (e.g. to access `next_url`):
+
+```typescript
 for await (const page of client.illusts.search({ word: 'hatsune miku' }).pages()) {
-  for (const illust of page.illusts) {
-    console.log(illust.id, illust.title)
-  }
+  console.log(`page has ${page.illusts.length} illusts`)
+}
+```
+
+### Enum-like option constants
+
+All option types ship both as `const` objects and as string literal types, so
+you can use the enum-like syntax or a plain string — whichever you prefer:
+
+```typescript
+import { BookmarkRestrict, RankingMode } from '@book000/pixivts'
+
+// Enum-like (shows up in IDE autocomplete)
+await client.illusts.bookmarkAdd({ illustId: 123, restrict: BookmarkRestrict.PUBLIC })
+await client.illusts.ranking({ mode: RankingMode.WEEK })
+
+// Plain string — also valid
+await client.illusts.bookmarkAdd({ illustId: 123, restrict: 'public' })
+```
+
+### Resuming pagination from a saved cursor
+
+Use `parseNextUrl` to extract typed cursor params from `next_url` so you can
+resume from a saved position across restarts:
+
+```typescript
+import { parseNextUrl } from '@book000/pixivts'
+
+const page = await client.users.bookmarks.illusts({ userId: client.userId })
+if (page.isOk && page.value.next_url) {
+  const cursor = parseNextUrl(page.value.next_url)
+  // Persist cursor.maxBookmarkId, then next time:
+  const resumed = await client.users.bookmarks.illusts({
+    userId: client.userId,
+    maxBookmarkId: cursor.maxBookmarkId,
+  })
 }
 ```
 

--- a/docs/db-mysql.md
+++ b/docs/db-mysql.md
@@ -1,0 +1,154 @@
+# MySQL Response Recorder
+
+`@book000/pixivts-db-mysql` is an optional add-on package that persists every pixiv API response to a MySQL database via [Drizzle ORM](https://orm.drizzle.team/).
+
+## Installation
+
+```shell
+npm install @book000/pixivts-db-mysql
+```
+
+Requires MySQL 5.7+ or MariaDB 10.3+.
+
+## Quick Start
+
+```typescript
+import { PixivClient } from '@book000/pixivts'
+import { createResponseRecorder } from '@book000/pixivts-db-mysql'
+
+const { interceptor, close } = await createResponseRecorder({
+  host: 'localhost',
+  user: 'pixiv',
+  password: 'secret',
+  database: 'pixivts',
+  bootstrap: true, // run CREATE TABLE IF NOT EXISTS on first run
+})
+
+const client = await PixivClient.of(process.env.PIXIV_REFRESH_TOKEN!, {
+  onResponse: interceptor,
+})
+
+// Every API call is now persisted automatically
+const result = await client.illusts.detail({ illustId: 12345 })
+// ...
+
+await close()
+```
+
+## Connection Options
+
+Options can be passed explicitly or set via environment variables.
+
+| Option | Env variable | Default | Description |
+|---|---|---|---|
+| `host` | `RESPONSE_DB_HOSTNAME` | `localhost` | Database hostname |
+| `port` | `RESPONSE_DB_PORT` | `3306` | Database port |
+| `user` | `RESPONSE_DB_USERNAME` | — | Database username |
+| `password` | `RESPONSE_DB_PASSWORD` | — | Database password |
+| `database` | `RESPONSE_DB_DATABASE` | — | Database name |
+| `bootstrap` | — | `false` | Run `CREATE TABLE IF NOT EXISTS` on startup |
+
+Environment variable example:
+
+```shell
+RESPONSE_DB_HOSTNAME=db.example.com
+RESPONSE_DB_USERNAME=pixiv
+RESPONSE_DB_PASSWORD=secret
+RESPONSE_DB_DATABASE=pixivts
+```
+
+```typescript
+// All connection options are read from env vars automatically
+const { interceptor, close } = await createResponseRecorder({ bootstrap: true })
+```
+
+## Schema
+
+Responses are stored in a single `responses` table.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | INT AUTO_INCREMENT | Primary key |
+| `method` | VARCHAR(10) | HTTP method (`GET` / `POST`) |
+| `endpoint` | VARCHAR(255) | API path (e.g. `/v1/illust/detail`) |
+| `url` | TEXT | Full request URL |
+| `url_hash` | VARCHAR(255) | SHA-256 of the URL (used for deduplication) |
+| `request_headers` | LONGTEXT | Serialised request headers (JSON) |
+| `request_body` | LONGTEXT | Request body (POST only) |
+| `response_type` | VARCHAR(10) | `JSON` or `TEXT` |
+| `status_code` | INT | HTTP status code |
+| `response_headers` | LONGTEXT | Serialised response headers (JSON) |
+| `response_body` | LONGTEXT | Raw response body |
+| `created_at` | DATETIME(3) | Timestamp |
+
+A unique composite index on `(method, endpoint, status_code, url_hash)` ensures each unique request/response is stored only once.
+
+## Query Helpers
+
+The package exports several helpers for reading recorded data.
+
+### `getResponses`
+
+Returns response rows from the last 90 days, newest first.
+
+```typescript
+import { getResponses } from '@book000/pixivts-db-mysql'
+
+const rows = await getResponses(db, { endpoint: '/v1/illust/detail' }, { page: 1, limit: 50 })
+```
+
+Filters:
+
+| Field | Type | Description |
+|---|---|---|
+| `method` | `string` | HTTP method |
+| `endpoint` | `string` | API endpoint path |
+| `statusCode` | `number` | HTTP status code |
+
+Pagination:
+
+| Field | Default | Description |
+|---|---|---|
+| `page` | `1` | 1-based page number |
+| `limit` | `100` | Items per page |
+
+### `getResponseCount`
+
+Returns the count of matching rows from the last 90 days.
+
+```typescript
+import { getResponseCount } from '@book000/pixivts-db-mysql'
+
+const total = await getResponseCount(db, { statusCode: 200 })
+```
+
+### `getEndpoints`
+
+Returns all unique `(method, endpoint, statusCode)` combinations seen in the last 90 days, sorted by count descending.
+
+```typescript
+import { getEndpoints } from '@book000/pixivts-db-mysql'
+
+const endpoints = await getEndpoints(db)
+// [{ method: 'GET', endpoint: '/v1/illust/detail', statusCode: 200, count: 42 }, ...]
+```
+
+## Custom Queries
+
+The `db` field in the bundle is a typed Drizzle ORM instance. Use it for any query not covered by the helpers.
+
+```typescript
+import { responsesTable } from '@book000/pixivts-db-mysql'
+import { eq } from 'drizzle-orm'
+
+const { interceptor, db, close } = await createResponseRecorder({ bootstrap: true })
+const client = await PixivClient.of(token, { onResponse: interceptor })
+
+// Custom query: fetch all 429 responses
+const rateLimited = await db
+  .select()
+  .from(responsesTable)
+  .where(eq(responsesTable.statusCode, 429))
+
+await close()
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,48 @@
+# Getting Started
+
+## Installation
+
+```shell
+npm install @book000/pixivts
+# or
+pnpm add @book000/pixivts
+```
+
+## Authentication
+
+Create a client by passing your Pixiv refresh token.
+`PixivClient.of` performs the initial token exchange and stores the access
+token internally — subsequent calls refresh it automatically on 401.
+
+```typescript
+import { PixivClient } from '@book000/pixivts'
+
+const client = await PixivClient.of(process.env.PIXIV_REFRESH_TOKEN!)
+
+// Authenticated user ID (number)
+console.log(client.userId)
+```
+
+## Result type
+
+Every API method returns `Result<T, PixivError>` — there are no thrown
+exceptions for API-level errors.
+Check `result.isOk` to narrow the union before accessing `.value` or `.error`:
+
+```typescript
+const result = await client.illusts.detail({ illustId: 12345 })
+
+if (result.isOk) {
+  console.log(result.value.illust.title) // IntelliSense shows .value here
+} else {
+  console.error(result.error)            // IntelliSense shows .error here
+}
+```
+
+You can also use the chainable helpers:
+
+```typescript
+const title = await client.illusts.detail({ illustId: 12345 })
+  .map((res) => res.illust.title)
+  .unwrapOr('(unknown)')
+```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,164 @@
+# Migration Guide: ≤ 0.55.1 → ≥ 0.56.2
+
+Version 0.56.2 is a **breaking rewrite**. This guide maps patterns from 0.55.1 and earlier to the current API.
+
+## Package Structure
+
+The previous version was a single package. The current version is a pnpm monorepo with two packages:
+
+| ≤ 0.55.1 | ≥ 0.56.2 |
+|---|---|
+| `@book000/pixivts` (fetch-based, CJS) | `@book000/pixivts` (fetch-based, ESM+CJS) |
+| `saving-responses/` (TypeORM + MySQL built-in) | `@book000/pixivts-db-mysql` (optional, Drizzle + MySQL) |
+
+## Creating a Client
+
+```typescript
+// ≤ 0.55.1
+import { Pixiv } from '@book000/pixivts'
+const pixiv = await Pixiv.of(refreshToken)
+
+// ≥ 0.56.2
+import { PixivClient } from '@book000/pixivts'
+const client = await PixivClient.of(refreshToken)
+```
+
+## Error Handling
+
+The previous version threw errors on failure. The current version returns `Result<T, PixivError>` — no thrown exceptions.
+
+```typescript
+// ≤ 0.55.1
+try {
+  const res = await pixiv.illustDetail({ illustId })
+  console.log(res.data.illust.title)
+} catch (err) {
+  console.error(err)
+}
+
+// ≥ 0.56.2
+const result = await client.illusts.detail({ illustId })
+if (result.isOk) {
+  console.log(result.value.illust.title)
+} else {
+  console.error(result.error.type)
+}
+```
+
+## Method Mapping
+
+| ≤ 0.55.1 method | ≥ 0.56.2 method |
+|---|---|
+| `pixiv.illustDetail({ illustId })` | `client.illusts.detail({ illustId })` |
+| `pixiv.illustRelated({ illustId })` | `client.illusts.related({ illustId })` |
+| `pixiv.searchIllust({ word })` | `client.illusts.search({ word })` |
+| `pixiv.illustRanking(opts)` | `client.illusts.ranking(opts)` |
+| `pixiv.illustRecommended(opts)` | `client.illusts.recommended(opts)` |
+| `pixiv.illustSeries({ illustSeriesId })` | `client.illusts.series({ illustSeriesId })` |
+| `pixiv.illustBookmarkAdd(opts)` | `client.illusts.bookmarkAdd(opts)` |
+| `pixiv.illustBookmarkDelete(opts)` | `client.illusts.bookmarkDelete(opts)` |
+| `pixiv.novelDetail({ novelId })` | `client.novels.detail({ novelId })` |
+| `pixiv.novelText({ novelId })` | `client.novels.text({ novelId })` |
+| `pixiv.novelRelated({ novelId })` | `client.novels.related({ novelId })` |
+| `pixiv.searchNovel({ word })` | `client.novels.search({ word })` |
+| `pixiv.novelRanking(opts)` | `client.novels.ranking(opts)` |
+| `pixiv.novelRecommended(opts)` | `client.novels.recommended(opts)` |
+| `pixiv.novelSeries({ seriesId })` | `client.novels.series({ seriesId })` |
+| `pixiv.novelBookmarkAdd(opts)` | `client.novels.bookmarkAdd(opts)` |
+| `pixiv.novelBookmarkDelete(opts)` | `client.novels.bookmarkDelete(opts)` |
+| `pixiv.userDetail({ userId })` | `client.users.detail({ userId })` |
+| `pixiv.userIllusts({ userId })` | `client.users.illusts({ userId })` |
+| `pixiv.userNovels({ userId })` | `client.users.novels({ userId })` |
+| `pixiv.userFollowing(opts)` | `client.users.following(opts)` |
+| `pixiv.userFollowAdd(opts)` | `client.users.followAdd(opts)` |
+| `pixiv.userFollowDelete(opts)` | `client.users.followDelete(opts)` |
+| `pixiv.userBookmarksIllust(opts)` | `client.users.bookmarks.illusts(opts)` |
+| `pixiv.userBookmarksNovel(opts)` | `client.users.bookmarks.novels(opts)` |
+| `pixiv.mangaRecommended(opts)` | `client.manga.recommended(opts)` |
+| `pixiv.ugoiraMetadata({ illustId })` | `client.ugoira.metadata({ illustId })` |
+| `pixiv.getImageStream(url)` | `client.images.fetch(url)` |
+
+## Pagination
+
+The previous version returned the raw API response including `next_url`. The current version provides a `PaginatedResultAsync` with async generators.
+
+```typescript
+// ≤ 0.55.1
+let offset = 0
+while (true) {
+  const res = await pixiv.searchIllust({ word: 'hatsune miku', offset })
+  // process res.data.illusts
+  if (!res.data.next_url) break
+  offset += res.data.illusts.length
+}
+
+// ≥ 0.56.2 — iterate pages
+for await (const page of client.illusts.search({ word: 'hatsune miku' }).pages()) {
+  // process page.illusts
+}
+
+// ≥ 0.56.2 — iterate all items across pages (async generator — throws on fetch error)
+for await (const illust of client.illusts.search({ word: 'hatsune miku' }).items()) {
+  console.log(illust) // IllustSimple
+}
+```
+
+## Response Type
+
+The previous version returned a custom `PixivApiResponse<T>` — you accessed the body via `.data`. The current version returns the unwrapped response body directly.
+
+```typescript
+// ≤ 0.55.1
+const res = await pixiv.illustDetail({ illustId })
+console.log(res.data.illust.title)  // .data because it's PixivApiResponse<T>
+
+// ≥ 0.56.2
+const result = await client.illusts.detail({ illustId })
+if (result.isOk) {
+  console.log(result.value.illust.title)  // no .data — value is the response body
+}
+```
+
+## MySQL Response Saving
+
+The previous version had response saving built into the core package via TypeORM. The current version moves this to the optional `@book000/pixivts-db-mysql` package using Drizzle ORM.
+
+```typescript
+// ≤ 0.55.1
+import { Pixiv } from '@book000/pixivts'
+const pixiv = await Pixiv.of(refreshToken, {
+  responseDatabase: {
+    host: 'localhost',
+    username: 'pixiv',
+    password: 'secret',
+    database: 'pixivts',
+    synchronize: true,
+  },
+})
+
+// ≥ 0.56.2
+import { PixivClient } from '@book000/pixivts'
+import { createResponseRecorder } from '@book000/pixivts-db-mysql'
+
+const { interceptor, close } = await createResponseRecorder({
+  host: 'localhost',
+  user: 'pixiv',
+  password: 'secret',
+  database: 'pixivts',
+  bootstrap: true,
+})
+const client = await PixivClient.of(refreshToken, { onResponse: interceptor })
+// ... use client ...
+await close()
+```
+
+## Dependencies Removed
+
+The following dependencies from ≤ 0.55.1 are no longer required:
+
+| Removed | Reason |
+|---|---|
+| `qs` | Replaced by `URLSearchParams` |
+| `typeorm` | Moved to `@book000/pixivts-db-mysql` (Drizzle) |
+| `typeorm-naming-strategies` | Same as above |
+| `snake-camel-types` | Replaced by local type utilities |

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,0 +1,103 @@
+# Option Constants
+
+All option types are exported as both a `const` object and a string literal
+type with the same name.
+Use whichever style you prefer — both are fully type-safe and interchangeable.
+
+```typescript
+import { BookmarkRestrict, RankingMode, SearchSort } from '@book000/pixivts'
+
+// Const-object style — shows up in IDE autocomplete
+await client.illusts.bookmarkAdd({ illustId: 123, restrict: BookmarkRestrict.PUBLIC })
+await client.illusts.ranking({ mode: RankingMode.WEEK })
+await client.illusts.search({ word: 'cat', sort: SearchSort.POPULAR_DESC })
+
+// Plain string literal — also valid
+await client.illusts.bookmarkAdd({ illustId: 123, restrict: 'public' })
+```
+
+## Available constants
+
+### `BookmarkRestrict`
+
+| Key | Value |
+|---|---|
+| `PUBLIC` | `'public'` |
+| `PRIVATE` | `'private'` |
+
+### `FollowRestrict`
+
+| Key | Value |
+|---|---|
+| `PUBLIC` | `'public'` |
+| `PRIVATE` | `'private'` |
+
+### `RankingMode`
+
+| Key | Value |
+|---|---|
+| `DAY` | `'day'` |
+| `DAY_MALE` | `'day_male'` |
+| `DAY_FEMALE` | `'day_female'` |
+| `WEEK` | `'week'` |
+| `WEEK_ORIGINAL` | `'week_original'` |
+| `WEEK_ROOKIE` | `'week_rookie'` |
+| `MONTH` | `'month'` |
+| `DAY_AI` | `'day_ai'` |
+| `DAY_R18` | `'day_r18'` |
+| `WEEK_R18` | `'week_r18'` |
+| `DAY_MALE_R18` | `'day_male_r18'` |
+| `DAY_FEMALE_R18` | `'day_female_r18'` |
+| `DAY_R18_AI` | `'day_r18_ai'` |
+
+### `NovelRankingMode`
+
+| Key | Value |
+|---|---|
+| `DAY` | `'day'` |
+| `WEEK` | `'week'` |
+| `DAY_MALE` | `'day_male'` |
+| `DAY_FEMALE` | `'day_female'` |
+| `WEEK_ROOKIE` | `'week_rookie'` |
+| `DAY_R18` | `'day_r18'` |
+| `WEEK_R18` | `'week_r18'` |
+| `DAY_R18_AI` | `'day_r18_ai'` |
+
+### `SearchTarget`
+
+| Key | Value |
+|---|---|
+| `PARTIAL_MATCH_FOR_TAGS` | `'partial_match_for_tags'` |
+| `EXACT_MATCH_FOR_TAGS` | `'exact_match_for_tags'` |
+| `TITLE_AND_CAPTION` | `'title_and_caption'` |
+| `KEYWORD` | `'keyword'` |
+
+### `SearchSort`
+
+| Key | Value |
+|---|---|
+| `DATE_DESC` | `'date_desc'` |
+| `DATE_ASC` | `'date_asc'` |
+| `POPULAR_DESC` | `'popular_desc'` |
+
+### `SearchDuration`
+
+| Key | Value |
+|---|---|
+| `WITHIN_LAST_DAY` | `'within_last_day'` |
+| `WITHIN_LAST_WEEK` | `'within_last_week'` |
+| `WITHIN_LAST_MONTH` | `'within_last_month'` |
+
+### `OSFilter`
+
+| Key | Value |
+|---|---|
+| `FOR_IOS` | `'for_ios'` |
+| `FOR_ANDROID` | `'for_android'` |
+
+### `UserIllustType`
+
+| Key | Value |
+|---|---|
+| `ILLUST` | `'illust'` |
+| `MANGA` | `'manga'` |

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -1,0 +1,72 @@
+# Pagination
+
+List endpoints return `PaginatedResultAsync`, which extends `ResultAsync` and
+adds two async generators.
+
+## `.items()` — stream every item across all pages
+
+```typescript
+for await (const illust of client.illusts.search({ word: 'hatsune miku' }).items()) {
+  console.log(illust.id, illust.title)
+}
+
+for await (const novel of client.users.bookmarks.novels({ userId: client.userId }).items()) {
+  console.log(novel.title)
+}
+```
+
+## `.pages()` — access the raw page object
+
+Use this when you need page-level metadata such as `next_url`:
+
+```typescript
+for await (const page of client.illusts.search({ word: 'hatsune miku' }).pages()) {
+  console.log(`page has ${page.illusts.length} illusts`)
+}
+```
+
+## Awaiting the first page directly
+
+`PaginatedResultAsync` is also directly `await`-able and returns only the
+first page as a `Result`:
+
+```typescript
+const page = await client.illusts.search({ word: 'cat' })
+if (page.isOk) {
+  console.log(page.value.illusts.length)
+}
+```
+
+## Resuming from a saved cursor
+
+Use `parseNextUrl` to extract typed cursor parameters from `next_url` so you
+can persist a position and resume across restarts.
+
+```typescript
+import { parseNextUrl } from '@book000/pixivts'
+
+const page = await client.users.bookmarks.illusts({ userId: client.userId })
+if (page.isOk && page.value.next_url) {
+  const cursor = parseNextUrl(page.value.next_url)
+  // cursor.maxBookmarkId is number | undefined — persist this value
+
+  // Next run: pass the saved cursor back
+  const resumed = await client.users.bookmarks.illusts({
+    userId: client.userId,
+    maxBookmarkId: cursor.maxBookmarkId,
+  })
+}
+```
+
+### Available cursor fields
+
+`ParsedNextUrl` contains only the pagination cursor fields (not the full
+query string). All fields are `number | undefined`.
+
+| Field | Endpoint |
+|---|---|
+| `maxBookmarkId` | `GET /v1/user/bookmarks/illust` |
+| `maxBookmarkIdForRecommend` | `GET /v1/illust/recommended`, `GET /v1/novel/recommended` |
+| `minBookmarkIdForRecentIllust` | `GET /v1/illust/recommended` |
+| `offset` | search, ranking, recommended, user lists, … |
+| `lastOrder` | `GET /v2/novel/series` |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,7 @@ const __dirname = nodePath.dirname(fileURLToPath(import.meta.url))
 export default [
   ...eslintConfig,
   {
-    ignores: ['**/dist/**', '**/coverage/**', 'docs/**'],
+    ignores: ['**/dist/**', '**/coverage/**', 'docs-out/**'],
   },
   {
     // Use projectService to auto-discover each package's tsconfig.json.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -77,7 +77,7 @@ export class PixivClient {
   get userId(): number {
     const id = Number(this.#auth.userId)
     if (Number.isNaN(id)) {
-      throw new Error(`Invalid userId: "${this.#auth.userId}"`)
+      throw new TypeError(`Invalid userId: "${this.#auth.userId}"`)
     }
     return id
   }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -75,7 +75,11 @@ export class PixivClient {
    * ```
    */
   get userId(): number {
-    return Number(this.#auth.userId)
+    const id = Number(this.#auth.userId)
+    if (Number.isNaN(id)) {
+      throw new Error(`Invalid userId: "${this.#auth.userId}"`)
+    }
+    return id
   }
 
   /**

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -61,12 +61,21 @@ export class PixivClient {
   }
 
   /**
-   * Numeric user ID of the authenticated account, as a string.
+   * Numeric user ID of the authenticated account.
    *
    * Available immediately after {@link PixivClient.of} resolves.
+   * The pixiv OAuth endpoint returns the ID as a string; this getter
+   * normalises it to `number` for consistency with resource method params
+   * (e.g. `UserBookmarksIllustParams.userId`).
+   *
+   * @example
+   * ```ts
+   * const client = await PixivClient.of(refreshToken)
+   * const bookmarks = await client.users.bookmarks.illusts({ userId: client.userId })
+   * ```
    */
-  get userId(): string {
-    return this.#auth.userId
+  get userId(): number {
+    return Number(this.#auth.userId)
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,10 @@ export type { Result, OkResult, ErrResult } from './result'
 export { PaginatedResultAsync, failedPaginated } from './paginated'
 export type { PagedResponse } from './paginated'
 
+// URL utilities
+export { parseNextUrl } from './params'
+export type { ParsedNextUrl } from './params'
+
 // Error types
 export { rateLimitError, authFailedError, networkError, apiError, PixivFetchError } from './errors'
 export type { PixivError } from './errors'
@@ -26,8 +30,8 @@ export type { PixivError } from './errors'
 // Interceptor (DB seam)
 export type { ResponseRecord, ResponseInterceptor, HttpMethod } from './interceptor'
 
-// Option types
-export type {
+// Option constants and types (exported as values so callers can use e.g. BookmarkRestrict.PUBLIC)
+export {
   SearchTarget,
   SearchSort,
   SearchDuration,

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -1,9 +1,18 @@
 /**
  * Public option types for @book000/pixivts.
  *
- * All types are string literal unions — NOT TypeScript enums — so callers
- * do not need to import a runtime value and the values are transparent in
- * serialised output.
+ * Each option is exported as both a runtime `const` object (for enum-like
+ * access, e.g. `BookmarkRestrict.PUBLIC`) and a TypeScript `type` (so plain
+ * string literals such as `'public'` are also accepted).
+ *
+ * @example
+ * ```ts
+ * // Enum-like usage
+ * await client.illusts.bookmarkAdd({ illustId: 123, restrict: BookmarkRestrict.PUBLIC })
+ *
+ * // Plain string literal — also valid
+ * await client.illusts.bookmarkAdd({ illustId: 123, restrict: 'public' })
+ * ```
  */
 
 /**
@@ -14,11 +23,13 @@
  * - `title_and_caption` — title or caption contains the word
  * - `keyword` — general keyword search (novel only)
  */
-export type SearchTarget =
-  | 'partial_match_for_tags'
-  | 'exact_match_for_tags'
-  | 'title_and_caption'
-  | 'keyword'
+export const SearchTarget = {
+  PARTIAL_MATCH_FOR_TAGS: 'partial_match_for_tags',
+  EXACT_MATCH_FOR_TAGS: 'exact_match_for_tags',
+  TITLE_AND_CAPTION: 'title_and_caption',
+  KEYWORD: 'keyword',
+} as const
+export type SearchTarget = (typeof SearchTarget)[keyof typeof SearchTarget]
 
 /**
  * Sort order for search results.
@@ -27,7 +38,12 @@ export type SearchTarget =
  * - `date_asc` — oldest first
  * - `popular_desc` — most bookmarks first (premium only)
  */
-export type SearchSort = 'date_desc' | 'date_asc' | 'popular_desc'
+export const SearchSort = {
+  DATE_DESC: 'date_desc',
+  DATE_ASC: 'date_asc',
+  POPULAR_DESC: 'popular_desc',
+} as const
+export type SearchSort = (typeof SearchSort)[keyof typeof SearchSort]
 
 /**
  * Date range filter for search results.
@@ -36,45 +52,51 @@ export type SearchSort = 'date_desc' | 'date_asc' | 'popular_desc'
  * - `within_last_week` — past 7 days
  * - `within_last_month` — past 30 days
  */
-export type SearchDuration =
-  | 'within_last_day'
-  | 'within_last_week'
-  | 'within_last_month'
+export const SearchDuration = {
+  WITHIN_LAST_DAY: 'within_last_day',
+  WITHIN_LAST_WEEK: 'within_last_week',
+  WITHIN_LAST_MONTH: 'within_last_month',
+} as const
+export type SearchDuration = (typeof SearchDuration)[keyof typeof SearchDuration]
 
 /**
  * Ranking mode for illust rankings.
  *
  * R-18 modes require a premium account with R-18 content enabled.
  */
-export type RankingMode =
-  | 'day'
-  | 'day_male'
-  | 'day_female'
-  | 'week_original'
-  | 'week_rookie'
-  | 'week'
-  | 'month'
-  | 'day_ai'
-  | 'day_r18'
-  | 'week_r18'
-  | 'day_male_r18'
-  | 'day_female_r18'
-  | 'day_r18_ai'
+export const RankingMode = {
+  DAY: 'day',
+  DAY_MALE: 'day_male',
+  DAY_FEMALE: 'day_female',
+  WEEK_ORIGINAL: 'week_original',
+  WEEK_ROOKIE: 'week_rookie',
+  WEEK: 'week',
+  MONTH: 'month',
+  DAY_AI: 'day_ai',
+  DAY_R18: 'day_r18',
+  WEEK_R18: 'week_r18',
+  DAY_MALE_R18: 'day_male_r18',
+  DAY_FEMALE_R18: 'day_female_r18',
+  DAY_R18_AI: 'day_r18_ai',
+} as const
+export type RankingMode = (typeof RankingMode)[keyof typeof RankingMode]
 
 /**
  * Ranking mode for novel rankings.
  *
  * R-18 modes require a premium account with R-18 content enabled.
  */
-export type NovelRankingMode =
-  | 'day'
-  | 'week'
-  | 'day_male'
-  | 'day_female'
-  | 'week_rookie'
-  | 'day_r18'
-  | 'week_r18'
-  | 'day_r18_ai'
+export const NovelRankingMode = {
+  DAY: 'day',
+  WEEK: 'week',
+  DAY_MALE: 'day_male',
+  DAY_FEMALE: 'day_female',
+  WEEK_ROOKIE: 'week_rookie',
+  DAY_R18: 'day_r18',
+  WEEK_R18: 'week_r18',
+  DAY_R18_AI: 'day_r18_ai',
+} as const
+export type NovelRankingMode = (typeof NovelRankingMode)[keyof typeof NovelRankingMode]
 
 /**
  * Visibility restriction for bookmarks.
@@ -82,7 +104,11 @@ export type NovelRankingMode =
  * - `public` — publicly visible (default)
  * - `private` — visible only to the owner
  */
-export type BookmarkRestrict = 'public' | 'private'
+export const BookmarkRestrict = {
+  PUBLIC: 'public',
+  PRIVATE: 'private',
+} as const
+export type BookmarkRestrict = (typeof BookmarkRestrict)[keyof typeof BookmarkRestrict]
 
 /**
  * Visibility restriction for follows.
@@ -90,7 +116,11 @@ export type BookmarkRestrict = 'public' | 'private'
  * - `public` — publicly visible (default)
  * - `private` — visible only to the owner
  */
-export type FollowRestrict = 'public' | 'private'
+export const FollowRestrict = {
+  PUBLIC: 'public',
+  PRIVATE: 'private',
+} as const
+export type FollowRestrict = (typeof FollowRestrict)[keyof typeof FollowRestrict]
 
 /**
  * OS filter used to request works compatible with the given platform.
@@ -98,7 +128,11 @@ export type FollowRestrict = 'public' | 'private'
  * - `for_ios` — iOS-compatible works (default)
  * - `for_android` — Android-compatible works
  */
-export type OSFilter = 'for_ios' | 'for_android'
+export const OSFilter = {
+  FOR_IOS: 'for_ios',
+  FOR_ANDROID: 'for_android',
+} as const
+export type OSFilter = (typeof OSFilter)[keyof typeof OSFilter]
 
 /**
  * Work type filter for user illust listings.
@@ -106,4 +140,8 @@ export type OSFilter = 'for_ios' | 'for_android'
  * - `illust` — illustrations only
  * - `manga` — manga only
  */
-export type UserIllustType = 'illust' | 'manga'
+export const UserIllustType = {
+  ILLUST: 'illust',
+  MANGA: 'manga',
+} as const
+export type UserIllustType = (typeof UserIllustType)[keyof typeof UserIllustType]

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -87,3 +87,85 @@ export function buildParams(
 ): URLSearchParams {
   return buildSearchParams(toSnakeKeys(params) as Record<string, ParamValue>)
 }
+
+// ---------------------------------------------------------------------------
+// parseNextUrl
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed cursor parameters extracted from a pixiv `next_url`.
+ *
+ * Different endpoints use different cursor fields; only the fields present
+ * in the URL will be defined.
+ *
+ * | Field | Endpoint(s) |
+ * |---|---|
+ * | `maxBookmarkId` | `GET /v1/user/bookmarks/illust` |
+ * | `maxBookmarkIdForRecommend` | `GET /v1/illust/recommended`, `GET /v1/novel/recommended` |
+ * | `minBookmarkIdForRecentIllust` | `GET /v1/illust/recommended` |
+ * | `offset` | search, ranking, recommended, user lists, … |
+ * | `lastOrder` | `GET /v2/novel/series` |
+ */
+export interface ParsedNextUrl {
+  /** Cursor for `GET /v1/user/bookmarks/illust`. */
+  maxBookmarkId?: number
+  /** Cursor for `GET /v1/illust/recommended` and `GET /v1/novel/recommended`. */
+  maxBookmarkIdForRecommend?: number
+  /** Secondary cursor for `GET /v1/illust/recommended`. */
+  minBookmarkIdForRecentIllust?: number
+  /** Zero-based offset for general list endpoints. */
+  offset?: number
+  /** Cursor for `GET /v2/novel/series`. */
+  lastOrder?: number
+}
+
+/**
+ * Parses a pixiv `next_url` into a typed cursor object.
+ *
+ * Pass the `next_url` field from any paginated response to extract the
+ * cursor parameters needed to resume pagination from a saved position.
+ *
+ * @example
+ * ```ts
+ * const page = await client.users.bookmarks.illusts({ userId: client.userId })
+ * if (page.isOk && page.value.next_url) {
+ *   const cursor = parseNextUrl(page.value.next_url)
+ *   // Resume later:
+ *   const next = await client.users.bookmarks.illusts({
+ *     userId: client.userId,
+ *     maxBookmarkId: cursor.maxBookmarkId,
+ *   })
+ * }
+ * ```
+ *
+ * @param url - The `next_url` string returned by a pixiv list endpoint
+ * @returns Typed cursor parameters; fields absent in the URL are `undefined`
+ */
+export function parseNextUrl(url: string): ParsedNextUrl {
+  const usp = new URL(url).searchParams
+  const result: ParsedNextUrl = {}
+
+  const toNum = (key: string): number | undefined => {
+    const v = usp.get(key)
+    return v === null ? undefined : Number(v)
+  }
+
+  const maxBookmarkId = toNum('max_bookmark_id')
+  if (maxBookmarkId !== undefined) result.maxBookmarkId = maxBookmarkId
+
+  const maxBookmarkIdForRecommend = toNum('max_bookmark_id_for_recommend')
+  if (maxBookmarkIdForRecommend !== undefined)
+    result.maxBookmarkIdForRecommend = maxBookmarkIdForRecommend
+
+  const minBookmarkIdForRecentIllust = toNum('min_bookmark_id_for_recent_illust')
+  if (minBookmarkIdForRecentIllust !== undefined)
+    result.minBookmarkIdForRecentIllust = minBookmarkIdForRecentIllust
+
+  const offset = toNum('offset')
+  if (offset !== undefined) result.offset = offset
+
+  const lastOrder = toNum('last_order')
+  if (lastOrder !== undefined) result.lastOrder = lastOrder
+
+  return result
+}

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -147,7 +147,9 @@ export function parseNextUrl(url: string): ParsedNextUrl {
 
   const toNum = (key: string): number | undefined => {
     const v = usp.get(key)
-    return v === null ? undefined : Number(v)
+    if (v === null || v === '') return undefined
+    const n = Number(v)
+    return Number.isNaN(n) ? undefined : n
   }
 
   const maxBookmarkId = toNum('max_bookmark_id')

--- a/packages/core/src/resources/illusts.ts
+++ b/packages/core/src/resources/illusts.ts
@@ -81,6 +81,16 @@ export interface IllustRecommendedParams {
   filter?: OSFilter
   /** Zero-based offset for pagination. */
   offset?: number
+  /**
+   * Cursor for resuming pagination: the `maxBookmarkIdForRecommend` value
+   * extracted from a previous page's `next_url` via {@link parseNextUrl}.
+   */
+  maxBookmarkIdForRecommend?: number
+  /**
+   * Secondary cursor for resuming pagination: the `minBookmarkIdForRecentIllust`
+   * value extracted from a previous page's `next_url` via {@link parseNextUrl}.
+   */
+  minBookmarkIdForRecentIllust?: number
 }
 
 /** Parameters for fetching an illust series. */
@@ -120,6 +130,16 @@ export class IllustResource {
    * GET /v1/illust/detail
    *
    * @param params - Request parameters
+   *
+   * @example
+   * ```ts
+   * const result = await client.illusts.detail({ illustId: 12345 })
+   * if (result.isOk) {
+   *   console.log(result.value.illust.title)
+   * } else {
+   *   console.error(result.error)
+   * }
+   * ```
    */
   detail(
     params: IllustDetailParams
@@ -160,6 +180,20 @@ export class IllustResource {
    * GET /v1/search/illust
    *
    * @param params - Request parameters
+   *
+   * @example
+   * ```ts
+   * // Iterate all results across pages
+   * for await (const illust of client.illusts.search({ word: 'cat' }).items()) {
+   *   console.log(illust.title)
+   * }
+   *
+   * // Fetch only the first page
+   * const page = await client.illusts.search({ word: 'cat' })
+   * if (page.isOk) {
+   *   console.log(page.value.illusts.length)
+   * }
+   * ```
    */
   search(
     params: IllustSearchParams
@@ -229,6 +263,8 @@ export class IllustResource {
           includeRankingIllusts: true,
           includePrivacyPolicy: true,
           offset: params.offset,
+          maxBookmarkIdForRecommend: params.maxBookmarkIdForRecommend,
+          minBookmarkIdForRecentIllust: params.minBookmarkIdForRecentIllust,
         })
       ),
       this.#http,

--- a/packages/core/src/resources/novels.ts
+++ b/packages/core/src/resources/novels.ts
@@ -82,6 +82,11 @@ export interface NovelRecommendedParams {
   filter?: OSFilter
   /** Zero-based offset for pagination. */
   offset?: number
+  /**
+   * Cursor for resuming pagination: the `maxBookmarkIdForRecommend` value
+   * extracted from a previous page's `next_url` via {@link parseNextUrl}.
+   */
+  maxBookmarkIdForRecommend?: number
 }
 
 /** Parameters for fetching a novel series. */
@@ -121,6 +126,16 @@ export class NovelResource {
    * GET /v2/novel/detail
    *
    * @param params - Request parameters
+   *
+   * @example
+   * ```ts
+   * const result = await client.novels.detail({ novelId: 67890 })
+   * if (result.isOk) {
+   *   console.log(result.value.novel.title)
+   * } else {
+   *   console.error(result.error)
+   * }
+   * ```
    */
   detail(
     params: NovelDetailParams
@@ -172,6 +187,20 @@ export class NovelResource {
    * GET /v1/search/novel
    *
    * @param params - Request parameters
+   *
+   * @example
+   * ```ts
+   * // Iterate all results across pages
+   * for await (const novel of client.novels.search({ word: 'fantasy' }).items()) {
+   *   console.log(novel.title)
+   * }
+   *
+   * // Fetch only the first page
+   * const page = await client.novels.search({ word: 'fantasy' })
+   * if (page.isOk) {
+   *   console.log(page.value.novels.length)
+   * }
+   * ```
    */
   search(
     params: NovelSearchParams
@@ -237,6 +266,7 @@ export class NovelResource {
           includeRankingNovels: true,
           includePrivacyPolicy: true,
           offset: params.offset,
+          maxBookmarkIdForRecommend: params.maxBookmarkIdForRecommend,
         })
       ),
       this.#http,

--- a/packages/core/src/resources/users.ts
+++ b/packages/core/src/resources/users.ts
@@ -125,6 +125,25 @@ export class UserBookmarksResource {
    * GET /v1/user/bookmarks/illust
    *
    * @param params - Request parameters
+   *
+   * @example
+   * ```ts
+   * // Iterate all bookmarked illusts across pages
+   * for await (const illust of client.users.bookmarks.illusts({ userId: client.userId }).items()) {
+   *   console.log(illust.title)
+   * }
+   *
+   * // Resume from a saved cursor
+   * import { parseNextUrl } from '@book000/pixivts'
+   * const page = await client.users.bookmarks.illusts({ userId: client.userId })
+   * if (page.isOk && page.value.next_url) {
+   *   const cursor = parseNextUrl(page.value.next_url)
+   *   const next = await client.users.bookmarks.illusts({
+   *     userId: client.userId,
+   *     maxBookmarkId: cursor.maxBookmarkId,
+   *   })
+   * }
+   * ```
    */
   illusts(
     params: UserBookmarksIllustParams
@@ -151,6 +170,14 @@ export class UserBookmarksResource {
    * GET /v1/user/bookmarks/novel
    *
    * @param params - Request parameters
+   *
+   * @example
+   * ```ts
+   * // Iterate all bookmarked novels across pages
+   * for await (const novel of client.users.bookmarks.novels({ userId: client.userId }).items()) {
+   *   console.log(novel.title)
+   * }
+   * ```
    */
   novels(
     params: UserBookmarksNovelParams

--- a/packages/core/tests/client.test.ts
+++ b/packages/core/tests/client.test.ts
@@ -496,3 +496,17 @@ describe('images.fetch()', () => {
     }
   })
 })
+
+describe('client.userId', () => {
+  it('returns a number even though the OAuth response contains a string', async () => {
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    // AUTH_RESPONSE has user.id = '42' (string); userId should be coerced to number
+    expect(typeof client.userId).toBe('number')
+    expect(client.userId).toBe(42)
+  })
+})

--- a/packages/core/tests/client.test.ts
+++ b/packages/core/tests/client.test.ts
@@ -509,4 +509,17 @@ describe('client.userId', () => {
     expect(typeof client.userId).toBe('number')
     expect(client.userId).toBe(42)
   })
+
+  it('throws when the OAuth response contains a non-numeric user id', async () => {
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json({
+          ...AUTH_RESPONSE,
+          user: { id: 'not-a-number' },
+        })
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    expect(() => client.userId).toThrow('Invalid userId')
+  })
 })

--- a/packages/core/tests/client.test.ts
+++ b/packages/core/tests/client.test.ts
@@ -520,6 +520,7 @@ describe('client.userId', () => {
       )
     )
     const client = await PixivClient.of('test-refresh-token')
+    expect(() => client.userId).toThrow(TypeError)
     expect(() => client.userId).toThrow('Invalid userId')
   })
 })

--- a/packages/core/tests/params.test.ts
+++ b/packages/core/tests/params.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { buildParams, buildSearchParams, camelToSnake, toSnakeKeys } from '../src/params'
+import {
+  buildParams,
+  buildSearchParams,
+  camelToSnake,
+  parseNextUrl,
+  toSnakeKeys,
+} from '../src/params'
 
 describe('camelToSnake()', () => {
   it('converts a single uppercase letter', () => {
@@ -88,5 +94,50 @@ describe('buildParams()', () => {
     const usp = buildParams({ tags: ['foo', 'bar'] })
     expect(usp.getAll('tags[]')).toEqual(['foo', 'bar'])
     expect(usp.has('tags')).toBe(false)
+  })
+})
+
+describe('parseNextUrl()', () => {
+  it('extracts offset', () => {
+    const result = parseNextUrl(
+      'https://app-api.pixiv.net/v1/search/illust?word=cat&offset=30'
+    )
+    expect(result.offset).toBe(30)
+    expect(result.maxBookmarkId).toBeUndefined()
+  })
+
+  it('extracts max_bookmark_id', () => {
+    const result = parseNextUrl(
+      'https://app-api.pixiv.net/v1/user/bookmarks/illust?user_id=1&max_bookmark_id=99999'
+    )
+    expect(result.maxBookmarkId).toBe(99_999)
+    expect(result.offset).toBeUndefined()
+  })
+
+  it('extracts last_order', () => {
+    const result = parseNextUrl(
+      'https://app-api.pixiv.net/v2/novel/series?series_id=1&last_order=10'
+    )
+    expect(result.lastOrder).toBe(10)
+  })
+
+  it('extracts max_bookmark_id_for_recommend and min_bookmark_id_for_recent_illust', () => {
+    const result = parseNextUrl(
+      'https://app-api.pixiv.net/v1/illust/recommended?max_bookmark_id_for_recommend=888&min_bookmark_id_for_recent_illust=777'
+    )
+    expect(result.maxBookmarkIdForRecommend).toBe(888)
+    expect(result.minBookmarkIdForRecentIllust).toBe(777)
+  })
+
+  it('returns an empty object when no cursor params are present', () => {
+    const result = parseNextUrl('https://app-api.pixiv.net/v1/illust/ranking?filter=for_ios')
+    expect(result).toEqual({})
+  })
+
+  it('returns numeric values, not strings', () => {
+    const result = parseNextUrl(
+      'https://app-api.pixiv.net/v1/search/illust?offset=60'
+    )
+    expect(typeof result.offset).toBe('number')
   })
 })

--- a/packages/core/tests/params.test.ts
+++ b/packages/core/tests/params.test.ts
@@ -140,4 +140,12 @@ describe('parseNextUrl()', () => {
     )
     expect(typeof result.offset).toBe('number')
   })
+
+  it('returns undefined for non-numeric cursor params', () => {
+    const result = parseNextUrl(
+      'https://app-api.pixiv.net/v1/search/illust?offset=abc&max_bookmark_id='
+    )
+    expect(result.offset).toBeUndefined()
+    expect(result.maxBookmarkId).toBeUndefined()
+  })
 })

--- a/packages/core/typedoc.json
+++ b/packages/core/typedoc.json
@@ -1,9 +1,11 @@
 {
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["src/index.ts"],
-  "out": "../../docs",
+  "out": "../../docs-out",
   "name": "@book000/pixivts",
-  "readme": "README.md",
+  "readme": "../../README.md",
+  "projectDocuments": ["../../docs/*.md"],
+  "searchInDocuments": true,
   "gitRevision": "master",
   "includeVersion": true,
   "excludePrivate": true,


### PR DESCRIPTION
## Summary

Implements a set of usability improvements identified after the 0.56.2 redesign.

## Changes

### API Improvements

**Option constants as `as const` objects**
- Converted all string literal union types (`SearchTarget`, `SearchSort`, `SearchDuration`, `RankingMode`, `NovelRankingMode`, `BookmarkRestrict`, `FollowRestrict`, `OSFilter`, `UserIllustType`) to `as const` object + same-named type pattern
- Callers can now use `BookmarkRestrict.PUBLIC` instead of the raw string `'public'`
- Runtime values are available; tree-shaking still works

**`client.userId` returns `number`**
- Changed the `userId` getter from `string` to `number`
- Eliminates the need for callers to wrap with `Number()` when passing to params like `{ userId: client.userId }`

**Typed cursor parameters from `next_url`**
- Added `parseNextUrl(url: string): ParsedNextUrl` to extract named cursor fields from pixiv's `next_url` query strings
- Fields: `maxBookmarkId`, `maxBookmarkIdForRecommend`, `minBookmarkIdForRecentIllust`, `offset`, `lastOrder`
- Added `maxBookmarkIdForRecommend` and `minBookmarkIdForRecentIllust` to `IllustRecommendedParams` and `NovelRecommendedParams`

**JSDoc `@example` additions**
- Added `@example` blocks to `illusts.detail()`, `illusts.search()`, `novels.detail()`, `novels.search()`, `users.bookmarks.illusts()`, `users.bookmarks.novels()`
- Examples demonstrate the cursor-resume pattern using `parseNextUrl`

### Documentation

- Reorganized documentation: TypeDoc output moves from `docs/` to `docs-out/`; `docs/` is now git-managed Markdown source
- TypeDoc `projectDocuments` integrates `docs/*.md` into the GitHub Pages Documents section
- New pages: Getting Started, Pagination, Option Constants, MySQL Recorder, Migration Guide
- `MIGRATION.md` moved to `docs/migration.md`
- README slimmed down to quick-start + links

## Testing

- Added tests for `parseNextUrl()`: offset, max_bookmark_id, last_order, recommend cursors, empty result, numeric return type
- Added test for `client.userId` returning `number`