### PR TITLE
fix(core): remove type alias exports for all option consts to fix value re-export in d.ts

### DIFF
--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -29,7 +29,6 @@ export const SearchTarget = {
   TITLE_AND_CAPTION: 'title_and_caption',
   KEYWORD: 'keyword',
 } as const
-export type SearchTarget = (typeof SearchTarget)[keyof typeof SearchTarget]
 
 /**
  * Sort order for search results.
@@ -43,7 +42,6 @@ export const SearchSort = {
   DATE_ASC: 'date_asc',
   POPULAR_DESC: 'popular_desc',
 } as const
-export type SearchSort = (typeof SearchSort)[keyof typeof SearchSort]
 
 /**
  * Date range filter for search results.
@@ -57,7 +55,6 @@ export const SearchDuration = {
   WITHIN_LAST_WEEK: 'within_last_week',
   WITHIN_LAST_MONTH: 'within_last_month',
 } as const
-export type SearchDuration = (typeof SearchDuration)[keyof typeof SearchDuration]
 
 /**
  * Ranking mode for illust rankings.
@@ -79,7 +76,6 @@ export const RankingMode = {
   DAY_FEMALE_R18: 'day_female_r18',
   DAY_R18_AI: 'day_r18_ai',
 } as const
-export type RankingMode = (typeof RankingMode)[keyof typeof RankingMode]
 
 /**
  * Ranking mode for novel rankings.
@@ -96,7 +92,6 @@ export const NovelRankingMode = {
   WEEK_R18: 'week_r18',
   DAY_R18_AI: 'day_r18_ai',
 } as const
-export type NovelRankingMode = (typeof NovelRankingMode)[keyof typeof NovelRankingMode]
 
 /**
  * Visibility restriction for bookmarks.
@@ -119,7 +114,6 @@ export const FollowRestrict = {
   PUBLIC: 'public',
   PRIVATE: 'private',
 } as const
-export type FollowRestrict = (typeof FollowRestrict)[keyof typeof FollowRestrict]
 
 /**
  * OS filter used to request works compatible with the given platform.
@@ -131,7 +125,6 @@ export const OSFilter = {
   FOR_IOS: 'for_ios',
   FOR_ANDROID: 'for_android',
 } as const
-export type OSFilter = (typeof OSFilter)[keyof typeof OSFilter]
 
 /**
  * Work type filter for user illust listings.
@@ -143,4 +136,3 @@ export const UserIllustType = {
   ILLUST: 'illust',
   MANGA: 'manga',
 } as const
-export type UserIllustType = (typeof UserIllustType)[keyof typeof UserIllustType]

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -1,9 +1,9 @@
 /**
- * Public option types for @book000/pixivts.
+ * Public option constants for @book000/pixivts.
  *
- * Each option is exported as both a runtime `const` object (for enum-like
- * access, e.g. `BookmarkRestrict.PUBLIC`) and a TypeScript `type` (so plain
- * string literals such as `'public'` are also accepted).
+ * Each option is exported as a runtime `const` object for enum-like access
+ * (e.g. `BookmarkRestrict.PUBLIC`). Plain string literals are also accepted
+ * wherever these values are used as parameters.
  *
  * @example
  * ```ts
@@ -108,7 +108,6 @@ export const BookmarkRestrict = {
   PUBLIC: 'public',
   PRIVATE: 'private',
 } as const
-export type BookmarkRestrict = (typeof BookmarkRestrict)[keyof typeof BookmarkRestrict]
 
 /**
  * Visibility restriction for follows.

--- a/packages/core/src/resources/illusts.ts
+++ b/packages/core/src/resources/illusts.ts
@@ -7,7 +7,6 @@ import { buildParams } from '../params'
 import { PaginatedResultAsync } from '../paginated'
 import type { ResultAsync } from '../result'
 import type {
-  BookmarkRestrict,
   OSFilter,
   RankingMode,
   SearchDuration,
@@ -106,7 +105,7 @@ export interface IllustBookmarkAddParams {
   /** ID of the illust to bookmark. */
   illustId: number
   /** Bookmark visibility (default: `"public"`). */
-  restrict?: BookmarkRestrict
+  restrict?: 'public' | 'private'
   /** Tags to attach to the bookmark. */
   tags?: string[]
 }

--- a/packages/core/src/resources/illusts.ts
+++ b/packages/core/src/resources/illusts.ts
@@ -6,7 +6,8 @@ import type { PixivError } from '../errors'
 import { buildParams } from '../params'
 import { PaginatedResultAsync } from '../paginated'
 import type { ResultAsync } from '../result'
-import type {
+import {
+  BookmarkRestrict,
   OSFilter,
   RankingMode,
   SearchDuration,
@@ -27,7 +28,7 @@ export interface IllustDetailParams {
   /** ID of the illust to fetch. */
   illustId: number
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
 }
 
 /** Parameters for fetching related illusts. */
@@ -37,7 +38,7 @@ export interface IllustRelatedParams {
   /** Additional seed illust IDs to influence recommendations. */
   seedIllustIds?: number[]
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
 }
 
 /** Parameters for searching illusts. */
@@ -45,17 +46,17 @@ export interface IllustSearchParams {
   /** Search keyword. */
   word: string
   /** How to match the keyword against works (default: `"partial_match_for_tags"`). */
-  searchTarget?: SearchTarget
+  searchTarget?: (typeof SearchTarget)[keyof typeof SearchTarget]
   /** Sort order for results (default: `"date_desc"`). */
-  sort?: SearchSort
+  sort?: (typeof SearchSort)[keyof typeof SearchSort]
   /** Date range preset filter (omit for no restriction). */
-  duration?: SearchDuration
+  duration?: (typeof SearchDuration)[keyof typeof SearchDuration]
   /** Start date for a custom date range (YYYY-MM-DD; requires `endDate`). */
   startDate?: string
   /** End date for a custom date range (YYYY-MM-DD; requires `startDate`). */
   endDate?: string
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** AI-generated content filter: `0` = hide AI works, `1` = show only AI works. */
   searchAiType?: 0 | 1
   /** Zero-based offset for pagination. */
@@ -65,9 +66,9 @@ export interface IllustSearchParams {
 /** Parameters for fetching the illust ranking. */
 export interface IllustRankingParams {
   /** Ranking category (default: `"day"`). */
-  mode?: RankingMode
+  mode?: (typeof RankingMode)[keyof typeof RankingMode]
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Specific date to fetch rankings for (YYYY-MM-DD; omit for the latest). */
   date?: string
   /** Zero-based offset for pagination. */
@@ -77,7 +78,7 @@ export interface IllustRankingParams {
 /** Parameters for fetching recommended illusts. */
 export interface IllustRecommendedParams {
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Zero-based offset for pagination. */
   offset?: number
   /**
@@ -97,7 +98,7 @@ export interface IllustSeriesParams {
   /** ID of the illust series to fetch. */
   illustSeriesId: number
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
 }
 
 /** Parameters for adding an illust bookmark. */
@@ -105,7 +106,7 @@ export interface IllustBookmarkAddParams {
   /** ID of the illust to bookmark. */
   illustId: number
   /** Bookmark visibility (default: `"public"`). */
-  restrict?: 'public' | 'private'
+  restrict?: (typeof BookmarkRestrict)[keyof typeof BookmarkRestrict]
   /** Tags to attach to the bookmark. */
   tags?: string[]
 }

--- a/packages/core/src/resources/manga.ts
+++ b/packages/core/src/resources/manga.ts
@@ -4,13 +4,13 @@
 import type { HttpClient } from '../http'
 import { buildParams } from '../params'
 import { PaginatedResultAsync } from '../paginated'
-import type { OSFilter } from '../options'
+import { OSFilter } from '../options'
 import type { MangaRecommendedPage, PixivIllustItem } from '../types'
 
 /** Parameters for fetching recommended manga. */
 export interface MangaRecommendedParams {
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Zero-based offset for pagination. */
   offset?: number
 }

--- a/packages/core/src/resources/novels.ts
+++ b/packages/core/src/resources/novels.ts
@@ -6,7 +6,8 @@ import type { PixivError } from '../errors'
 import { buildParams } from '../params'
 import { PaginatedResultAsync } from '../paginated'
 import type { ResultAsync } from '../result'
-import type {
+import {
+  BookmarkRestrict,
   NovelRankingMode,
   OSFilter,
   SearchDuration,
@@ -46,13 +47,13 @@ export interface NovelSearchParams {
   /** Search keyword. */
   word: string
   /** How to match the keyword against works (default: `"partial_match_for_tags"`). */
-  searchTarget?: SearchTarget
+  searchTarget?: (typeof SearchTarget)[keyof typeof SearchTarget]
   /** Sort order for results (default: `"date_desc"`). */
-  sort?: SearchSort
+  sort?: (typeof SearchSort)[keyof typeof SearchSort]
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Date range preset filter (omit for no restriction). */
-  duration?: SearchDuration
+  duration?: (typeof SearchDuration)[keyof typeof SearchDuration]
   /** Start date for a custom date range (YYYY-MM-DD; requires `endDate`). */
   startDate?: string
   /** End date for a custom date range (YYYY-MM-DD; requires `startDate`). */
@@ -66,9 +67,9 @@ export interface NovelSearchParams {
 /** Parameters for fetching the novel ranking. */
 export interface NovelRankingParams {
   /** Ranking category (default: `"day"`). */
-  mode?: NovelRankingMode
+  mode?: (typeof NovelRankingMode)[keyof typeof NovelRankingMode]
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Specific date to fetch rankings for (YYYY-MM-DD; omit for the latest). */
   date?: string
   /** Zero-based offset for pagination. */
@@ -78,7 +79,7 @@ export interface NovelRankingParams {
 /** Parameters for fetching recommended novels. */
 export interface NovelRecommendedParams {
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Zero-based offset for pagination. */
   offset?: number
   /**
@@ -101,7 +102,7 @@ export interface NovelBookmarkAddParams {
   /** ID of the novel to bookmark. */
   novelId: number
   /** Bookmark visibility (default: `"public"`). */
-  restrict?: 'public' | 'private'
+  restrict?: (typeof BookmarkRestrict)[keyof typeof BookmarkRestrict]
   /** Tags to attach to the bookmark. */
   tags?: string[]
 }

--- a/packages/core/src/resources/novels.ts
+++ b/packages/core/src/resources/novels.ts
@@ -7,7 +7,6 @@ import { buildParams } from '../params'
 import { PaginatedResultAsync } from '../paginated'
 import type { ResultAsync } from '../result'
 import type {
-  BookmarkRestrict,
   NovelRankingMode,
   OSFilter,
   SearchDuration,
@@ -102,7 +101,7 @@ export interface NovelBookmarkAddParams {
   /** ID of the novel to bookmark. */
   novelId: number
   /** Bookmark visibility (default: `"public"`). */
-  restrict?: BookmarkRestrict
+  restrict?: 'public' | 'private'
   /** Tags to attach to the bookmark. */
   tags?: string[]
 }

--- a/packages/core/src/resources/users.ts
+++ b/packages/core/src/resources/users.ts
@@ -7,7 +7,6 @@ import { buildParams } from '../params'
 import { PaginatedResultAsync } from '../paginated'
 import type { ResultAsync } from '../result'
 import type {
-  BookmarkRestrict,
   FollowRestrict,
   OSFilter,
   UserIllustType,
@@ -31,7 +30,7 @@ export interface UserBookmarksIllustParams {
   /** ID of the user whose bookmarks to fetch. */
   userId: number
   /** Visibility of the bookmarks to return (default: `"public"`). */
-  restrict?: BookmarkRestrict
+  restrict?: 'public' | 'private'
   /** OS filter to apply (default: `"for_ios"`). */
   filter?: OSFilter
   /** Limit results to bookmarks with this tag. */
@@ -47,7 +46,7 @@ export interface UserBookmarksNovelParams {
   /** ID of the user whose bookmarks to fetch. */
   userId: number
   /** Visibility of the bookmarks to return (default: `"public"`). */
-  restrict?: BookmarkRestrict
+  restrict?: 'public' | 'private'
   /** OS filter to apply (default: `"for_ios"`). */
   filter?: OSFilter
   /** Limit results to bookmarks with this tag. */

--- a/packages/core/src/resources/users.ts
+++ b/packages/core/src/resources/users.ts
@@ -6,7 +6,8 @@ import type { PixivError } from '../errors'
 import { buildParams } from '../params'
 import { PaginatedResultAsync } from '../paginated'
 import type { ResultAsync } from '../result'
-import type {
+import {
+  BookmarkRestrict,
   FollowRestrict,
   OSFilter,
   UserIllustType,
@@ -30,9 +31,9 @@ export interface UserBookmarksIllustParams {
   /** ID of the user whose bookmarks to fetch. */
   userId: number
   /** Visibility of the bookmarks to return (default: `"public"`). */
-  restrict?: 'public' | 'private'
+  restrict?: (typeof BookmarkRestrict)[keyof typeof BookmarkRestrict]
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Limit results to bookmarks with this tag. */
   tag?: string
   /** Fetch bookmarks older than this bookmark ID (cursor-based pagination). */
@@ -46,9 +47,9 @@ export interface UserBookmarksNovelParams {
   /** ID of the user whose bookmarks to fetch. */
   userId: number
   /** Visibility of the bookmarks to return (default: `"public"`). */
-  restrict?: 'public' | 'private'
+  restrict?: (typeof BookmarkRestrict)[keyof typeof BookmarkRestrict]
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Limit results to bookmarks with this tag. */
   tag?: string
   /** Fetch bookmarks older than this bookmark ID (cursor-based pagination). */
@@ -62,7 +63,7 @@ export interface UserDetailParams {
   /** ID of the user to fetch. */
   userId: number
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
 }
 
 /** Parameters for fetching a user's illusts. */
@@ -70,9 +71,9 @@ export interface UserIllustsParams {
   /** ID of the user whose illusts to fetch. */
   userId: number
   /** Work type to filter by (omit to return both illusts and manga). */
-  type?: UserIllustType
+  type?: (typeof UserIllustType)[keyof typeof UserIllustType]
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Zero-based offset for pagination. */
   offset?: number
 }
@@ -82,7 +83,7 @@ export interface UserNovelsParams {
   /** ID of the user whose novels to fetch. */
   userId: number
   /** OS filter to apply (default: `"for_ios"`). */
-  filter?: OSFilter
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Zero-based offset for pagination. */
   offset?: number
 }
@@ -92,7 +93,7 @@ export interface UserFollowingParams {
   /** ID of the user whose following list to fetch. */
   userId: number
   /** Visibility of the follows to return (default: `"public"`). */
-  restrict?: FollowRestrict
+  restrict?: (typeof FollowRestrict)[keyof typeof FollowRestrict]
   /** Zero-based offset for pagination. */
   offset?: number
 }
@@ -102,7 +103,7 @@ export interface UserFollowAddParams {
   /** ID of the user to follow. */
   userId: number
   /** Visibility of the follow (default: `"public"`). */
-  restrict?: FollowRestrict
+  restrict?: (typeof FollowRestrict)[keyof typeof FollowRestrict]
 }
 
 /** Parameters for unfollowing a user. */

--- a/packages/core/tests/options.test.ts
+++ b/packages/core/tests/options.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for option constants exported from options.ts.
+ *
+ * Verifies that:
+ * 1. Each const object contains the expected values.
+ * 2. Const values can be passed as API params (runtime usage via PixivClient).
+ */
+import { describe, expect, it } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from './msw/handlers'
+import { PixivClient } from '../src/client'
+import {
+  BookmarkRestrict,
+  FollowRestrict,
+  NovelRankingMode,
+  OSFilter,
+  RankingMode,
+  SearchDuration,
+  SearchSort,
+  SearchTarget,
+  UserIllustType,
+} from '../src/options'
+
+// ---------------------------------------------------------------------------
+// Auth stub reused across tests
+// ---------------------------------------------------------------------------
+
+const AUTH_RESPONSE = {
+  user: { id: '1' },
+  response: {
+    access_token: 'test-access-token',
+    refresh_token: 'test-refresh-token',
+  },
+}
+
+function stubAuth() {
+  server.use(
+    http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+      HttpResponse.json(AUTH_RESPONSE)
+    )
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Const value assertions
+// ---------------------------------------------------------------------------
+
+describe('BookmarkRestrict', () => {
+  it('has PUBLIC = "public"', () => {
+    expect(BookmarkRestrict.PUBLIC).toBe('public')
+  })
+  it('has PRIVATE = "private"', () => {
+    expect(BookmarkRestrict.PRIVATE).toBe('private')
+  })
+})
+
+describe('FollowRestrict', () => {
+  it('has PUBLIC = "public"', () => {
+    expect(FollowRestrict.PUBLIC).toBe('public')
+  })
+  it('has PRIVATE = "private"', () => {
+    expect(FollowRestrict.PRIVATE).toBe('private')
+  })
+})
+
+describe('OSFilter', () => {
+  it('has FOR_IOS = "for_ios"', () => {
+    expect(OSFilter.FOR_IOS).toBe('for_ios')
+  })
+  it('has FOR_ANDROID = "for_android"', () => {
+    expect(OSFilter.FOR_ANDROID).toBe('for_android')
+  })
+})
+
+describe('SearchTarget', () => {
+  it('has PARTIAL_MATCH_FOR_TAGS = "partial_match_for_tags"', () => {
+    expect(SearchTarget.PARTIAL_MATCH_FOR_TAGS).toBe('partial_match_for_tags')
+  })
+  it('has EXACT_MATCH_FOR_TAGS = "exact_match_for_tags"', () => {
+    expect(SearchTarget.EXACT_MATCH_FOR_TAGS).toBe('exact_match_for_tags')
+  })
+  it('has TITLE_AND_CAPTION = "title_and_caption"', () => {
+    expect(SearchTarget.TITLE_AND_CAPTION).toBe('title_and_caption')
+  })
+  it('has KEYWORD = "keyword"', () => {
+    expect(SearchTarget.KEYWORD).toBe('keyword')
+  })
+})
+
+describe('SearchSort', () => {
+  it('has DATE_DESC = "date_desc"', () => {
+    expect(SearchSort.DATE_DESC).toBe('date_desc')
+  })
+  it('has DATE_ASC = "date_asc"', () => {
+    expect(SearchSort.DATE_ASC).toBe('date_asc')
+  })
+  it('has POPULAR_DESC = "popular_desc"', () => {
+    expect(SearchSort.POPULAR_DESC).toBe('popular_desc')
+  })
+})
+
+describe('SearchDuration', () => {
+  it('has WITHIN_LAST_DAY = "within_last_day"', () => {
+    expect(SearchDuration.WITHIN_LAST_DAY).toBe('within_last_day')
+  })
+  it('has WITHIN_LAST_WEEK = "within_last_week"', () => {
+    expect(SearchDuration.WITHIN_LAST_WEEK).toBe('within_last_week')
+  })
+  it('has WITHIN_LAST_MONTH = "within_last_month"', () => {
+    expect(SearchDuration.WITHIN_LAST_MONTH).toBe('within_last_month')
+  })
+})
+
+describe('RankingMode', () => {
+  it('has DAY = "day"', () => {
+    expect(RankingMode.DAY).toBe('day')
+  })
+  it('has WEEK = "week"', () => {
+    expect(RankingMode.WEEK).toBe('week')
+  })
+  it('has MONTH = "month"', () => {
+    expect(RankingMode.MONTH).toBe('month')
+  })
+})
+
+describe('NovelRankingMode', () => {
+  it('has DAY = "day"', () => {
+    expect(NovelRankingMode.DAY).toBe('day')
+  })
+  it('has WEEK = "week"', () => {
+    expect(NovelRankingMode.WEEK).toBe('week')
+  })
+})
+
+describe('UserIllustType', () => {
+  it('has ILLUST = "illust"', () => {
+    expect(UserIllustType.ILLUST).toBe('illust')
+  })
+  it('has MANGA = "manga"', () => {
+    expect(UserIllustType.MANGA).toBe('manga')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Runtime usage: const values are accepted as API params
+// ---------------------------------------------------------------------------
+
+describe('BookmarkRestrict.PUBLIC used as API param', () => {
+  it('passes restrict=public to illusts.bookmarkAdd', async () => {
+    let capturedRestrict: string | null = null
+    stubAuth()
+    server.use(
+      http.post(
+        'https://app-api.pixiv.net/v2/illust/bookmark/add',
+        async ({ request }) => {
+          const body = await request.formData()
+          capturedRestrict = body.get('restrict') as string | null
+          return HttpResponse.json({})
+        }
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.illusts.bookmarkAdd({
+      illustId: 1,
+      restrict: BookmarkRestrict.PUBLIC,
+    })
+    expect(result.isOk).toBe(true)
+    expect(capturedRestrict).toBe('public')
+  })
+
+  it('passes restrict=private to illusts.bookmarkAdd', async () => {
+    let capturedRestrict: string | null = null
+    stubAuth()
+    server.use(
+      http.post(
+        'https://app-api.pixiv.net/v2/illust/bookmark/add',
+        async ({ request }) => {
+          const body = await request.formData()
+          capturedRestrict = body.get('restrict') as string | null
+          return HttpResponse.json({})
+        }
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.illusts.bookmarkAdd({
+      illustId: 1,
+      restrict: BookmarkRestrict.PRIVATE,
+    })
+    expect(result.isOk).toBe(true)
+    expect(capturedRestrict).toBe('private')
+  })
+})
+
+describe('SearchTarget used as API param', () => {
+  it('passes search_target to illusts.search', async () => {
+    let capturedTarget: string | null = null
+    stubAuth()
+    server.use(
+      http.get(
+        'https://app-api.pixiv.net/v1/search/illust',
+        ({ request }) => {
+          capturedTarget =
+            new URL(request.url).searchParams.get('search_target')
+          return HttpResponse.json({ illusts: [], next_url: null })
+        }
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    await client.illusts.search({
+      word: 'cat',
+      searchTarget: SearchTarget.EXACT_MATCH_FOR_TAGS,
+    })
+    expect(capturedTarget).toBe('exact_match_for_tags')
+  })
+})
+
+describe('RankingMode used as API param', () => {
+  it('passes mode to illusts.ranking', async () => {
+    let capturedMode: string | null = null
+    stubAuth()
+    server.use(
+      http.get(
+        'https://app-api.pixiv.net/v1/illust/ranking',
+        ({ request }) => {
+          capturedMode = new URL(request.url).searchParams.get('mode')
+          return HttpResponse.json({ illusts: [], next_url: null })
+        }
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    await client.illusts.ranking({ mode: RankingMode.WEEK })
+    expect(capturedMode).toBe('week')
+  })
+})
+
+describe('OSFilter used as API param', () => {
+  it('passes filter to illusts.detail', async () => {
+    let capturedFilter: string | null = null
+    stubAuth()
+    server.use(
+      http.get(
+        'https://app-api.pixiv.net/v1/illust/detail',
+        ({ request }) => {
+          capturedFilter = new URL(request.url).searchParams.get('filter')
+          return HttpResponse.json({
+            illust: {
+              id: 1,
+              title: 'T',
+              type: 'illust',
+              image_urls: {
+                square_medium: '',
+                medium: '',
+                large: '',
+              },
+              caption: '',
+              restrict: 0,
+              user: {
+                id: 1,
+                name: 'A',
+                account: 'a',
+                profile_image_urls: { medium: '' },
+              },
+              tags: [],
+              tools: [],
+              create_date: '2024-01-01T00:00:00+09:00',
+              page_count: 1,
+              width: 100,
+              height: 100,
+              sanity_level: 2,
+              x_restrict: 0,
+              series: null,
+              meta_single_page: { original_image_url: '' },
+              meta_pages: [],
+              total_view: 0,
+              total_bookmarks: 0,
+              is_bookmarked: false,
+              visible: true,
+              is_muted: false,
+              illust_ai_type: 0,
+              illust_book_style: 0,
+            },
+          })
+        }
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    await client.illusts.detail({ illustId: 1, filter: OSFilter.FOR_ANDROID })
+    expect(capturedFilter).toBe('for_android')
+  })
+})


### PR DESCRIPTION
## Summary

`tsup`'s `rollup-plugin-dts` collapsed the same-name `const` + `type` pattern into a type-only re-export in the bundled declaration file, making all option constants unusable as values (e.g. `BookmarkRestrict.PUBLIC`).

## Root Cause

```ts
// dist/index.d.ts (before) — type keyword applied to all option consts
export { type BookmarkRestrict, type SearchTarget, type OSFilter, ... }
//       ^^^^  runtime value was silently dropped
```

This caused the TypeScript error for all option constants:
> 'BookmarkRestrict' only refers to a type, but is being used as a value here.

## Changes

### `src/options.ts`
Remove all exported type aliases (`BookmarkRestrict`, `SearchSort`, `SearchTarget`, `SearchDuration`, `RankingMode`, `NovelRankingMode`, `FollowRestrict`, `OSFilter`, `UserIllustType`). The `const` value exports are kept.

### `src/resources/{illusts,novels,users,manga}.ts`
Change `import type { X }` to `import { X }` (value imports) and replace `param?: X` type annotations with `param?: (typeof X)[keyof typeof X]`, so types are derived directly from the const objects and stay in sync if values change.

### `tests/options.test.ts` (new)
Add unit tests that:
- Assert each const object holds the expected string values
- Verify const values are accepted as API params and forwarded correctly to HTTP requests (end-to-end via MSW stubs)

## After This Fix

```ts
// dist/index.d.ts (after) — no 'type' prefix; values correctly exported
export { BookmarkRestrict, SearchTarget, OSFilter, ... }
```

```ts
// All of the following work as expected
client.illusts.bookmarkAdd({ illustId: 123, restrict: BookmarkRestrict.PUBLIC })
client.illusts.search({ word: 'cat', searchTarget: SearchTarget.EXACT_MATCH_FOR_TAGS })
client.illusts.ranking({ mode: RankingMode.WEEK })
client.illusts.detail({ illustId: 123, filter: OSFilter.FOR_IOS })

// Plain string literals continue to work too
client.illusts.bookmarkAdd({ illustId: 123, restrict: 'public' })
```

## Breaking Change

All exported type aliases for option constants are removed. Code using these as type annotations (e.g. `const x: BookmarkRestrict`) will need to switch to `'public' | 'private'` or `(typeof BookmarkRestrict)[keyof typeof BookmarkRestrict]`.