### PR TITLE
fix(core): update zod to v4 and fix z.record() calls for v4 compatibility

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "typedoc": "0.28.19",
     "typescript": "6.0.3",
     "vitest": "3.2.6",
-    "zod": "3.25.76"
+    "zod": "4.4.3"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/core/src/schemas/error.ts
+++ b/packages/core/src/schemas/error.ts
@@ -26,7 +26,7 @@ export const PixivApiErrorBodySchema = z.object({
     userMessage: z.string(),
     message: z.string(),
     reason: z.string(),
-    userMessageDetails: z.record(z.unknown()).optional(),
+    userMessageDetails: z.record(z.string(), z.unknown()).optional(),
   }),
 })
 

--- a/packages/core/src/schemas/illust.ts
+++ b/packages/core/src/schemas/illust.ts
@@ -55,7 +55,7 @@ export const PixivIllustItemSchema = z.object({
    * For single-page works this is `{ originalImageUrl: string }`.
    * For multi-page works this is an empty object `{}`.
    */
-  metaSinglePage: z.union([MetaSinglePageSchema, z.record(z.never())]),
+  metaSinglePage: z.union([MetaSinglePageSchema, z.record(z.string(), z.never())]),
   metaPages: z.array(MetaPagesSchema),
   totalView: z.number(),
   totalBookmarks: z.number(),

--- a/packages/core/src/schemas/novel.ts
+++ b/packages/core/src/schemas/novel.ts
@@ -35,7 +35,7 @@ export const PixivNovelItemSchema = z.object({
    *
    * Contains `{}` (empty object) if the novel does not belong to a series.
    */
-  series: z.union([SeriesSchema, z.record(z.never())]),
+  series: z.union([SeriesSchema, z.record(z.string(), z.never())]),
   isBookmarked: z.boolean(),
   totalBookmarks: z.number(),
   totalView: z.number(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: 3.2.6
         version: 3.2.6(@types/node@24.13.2)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(tsx@4.22.4)(yaml@2.9.0)
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.4.3
+        version: 4.4.3
 
   packages/db-mysql:
     dependencies:
@@ -2927,8 +2927,8 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -5732,4 +5732,4 @@ snapshots:
 
   yocto-queue@1.2.2: {}
 
-  zod@3.25.76: {}
+  zod@4.4.3: {}


### PR DESCRIPTION
## Summary

Addresses the CI failure in Renovate PR #1653 (chore(deps): update dependency zod to v4).

### Root cause

zod v4 removed the single-argument form of `z.record()`. Three call sites in the internal schemas used the old form:

| File | Old | New |
|---|---|---|
| `src/schemas/error.ts:29` | `z.record(z.unknown())` | `z.record(z.string(), z.unknown())` |
| `src/schemas/illust.ts:58` | `z.record(z.never())` | `z.record(z.string(), z.never())` |
| `src/schemas/novel.ts:38` | `z.record(z.never())` | `z.record(z.string(), z.never())` |

### Verification

- `pnpm lint` passes (TS2554 errors resolved)
- `pnpm test` passes (160 tests)
- `dts:guard` passes (no zod reference leaked into public `.d.ts`)

### Note on scope

These schemas are internal-only (not exported from the package barrel), so there is no impact on the public API.