### PR TITLE
fix(ci): fix publishCmd DIST_TAG expansion in .releaserc.json

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -26,7 +26,7 @@
     ["@semantic-release/release-notes-generator", { "preset": "conventionalcommits" }],
     ["@semantic-release/exec", {
       "prepareCmd": "npm version --no-git-tag-version ${nextRelease.version} --prefix packages/core && npm version --no-git-tag-version ${nextRelease.version} --prefix packages/db-mysql",
-      "publishCmd": "CHANNEL=\"${nextRelease.channel}\"; DIST_TAG=\"${CHANNEL:-latest}\"; pnpm --filter @book000/pixivts publish --access public --no-git-checks --ignore-scripts --tag \"$DIST_TAG\"; pnpm --filter @book000/pixivts-db-mysql publish --access public --no-git-checks --ignore-scripts --tag \"$DIST_TAG\""
+      "publishCmd": "DIST_TAG=\"${nextRelease.channel || 'latest'}\"; pnpm --filter @book000/pixivts publish --access public --no-git-checks --ignore-scripts --tag \"$DIST_TAG\"; pnpm --filter @book000/pixivts-db-mysql publish --access public --no-git-checks --ignore-scripts --tag \"$DIST_TAG\""
     }],
     ["@semantic-release/github", { "successComment": false, "failComment": false }]
   ]

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -26,7 +26,7 @@
     ["@semantic-release/release-notes-generator", { "preset": "conventionalcommits" }],
     ["@semantic-release/exec", {
       "prepareCmd": "npm version --no-git-tag-version ${nextRelease.version} --prefix packages/core && npm version --no-git-tag-version ${nextRelease.version} --prefix packages/db-mysql",
-      "publishCmd": "DIST_TAG=\"${nextRelease.channel || 'latest'}\"; pnpm --filter @book000/pixivts publish --access public --no-git-checks --ignore-scripts --tag \"$DIST_TAG\"; pnpm --filter @book000/pixivts-db-mysql publish --access public --no-git-checks --ignore-scripts --tag \"$DIST_TAG\""
+      "publishCmd": "DIST_TAG=\"${nextRelease.channel || 'latest'}\" && pnpm --filter @book000/pixivts publish --access public --no-git-checks --ignore-scripts --tag \"$DIST_TAG\" && pnpm --filter @book000/pixivts-db-mysql publish --access public --no-git-checks --ignore-scripts --tag \"$DIST_TAG\""
     }],
     ["@semantic-release/github", { "successComment": false, "failComment": false }]
   ]


### PR DESCRIPTION
## Summary

Fixes a `SyntaxError` that caused the Release workflow to fail on the first run.

## Root Cause

`${CHANNEL:-latest}` in `publishCmd` was parsed by **lodash template** as a JavaScript expression. The `:-` operator is not valid JS, causing `SyntaxError: Unexpected token ':'`.

Lodash template intercepts **all** `${...}` patterns. Bash default-value expansion syntax `${VAR:-default}` is incompatible with lodash template strings.

## Fix

Replace with a single lodash template expression that computes the dist-tag directly in JS:

- Old: `CHANNEL="${nextRelease.channel}"; DIST_TAG="${CHANNEL:-latest}"`
- New: `DIST_TAG="${nextRelease.channel || 'latest'}"`

Verified with lodash 4.18.1:
- master (channel: `null`) → `DIST_TAG="latest"`
- develop (channel: `"beta"`) → `DIST_TAG="beta"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)