### PR TITLE
fix(ci): set explicit channel 'beta' for develop branch in .releaserc.json

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,7 @@
   "branches": [
     "master",
     "main",
-    { "name": "develop", "prerelease": "beta" }
+    { "name": "develop", "prerelease": "beta", "channel": "beta" }
   ],
   "tagFormat": "v${version}",
   "plugins": [


### PR DESCRIPTION
## Summary

Fixes the npm dist-tag for beta releases: packages were being published under `@develop` instead of `@beta`.

## Root Cause

In semantic-release, `nextRelease.channel` returns the **branch name** (`"develop"`) when no explicit `channel` is set on a `prerelease` branch config. The `prerelease: "beta"` value is only used as the version identifier (e.g. `0.60.0-beta.2`), not as the npm dist-tag.

## Changes

``.releaserc.json`` — add `"channel": "beta"` to the develop branch entry:

```diff
-{ "name": "develop", "prerelease": "beta" }
+{ "name": "develop", "prerelease": "beta", "channel": "beta" }
```

## Verification

After merging, the next develop push will publish with `--tag beta`, making the package installable via `npm install @book000/pixivts@beta` instead of the confusing `@develop` tag.