### PR TITLE
fix(ci): address Copilot review findings from release PR

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -186,4 +186,4 @@ jobs:
               --body-file /tmp/pr-body.md
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -179,11 +179,13 @@ jobs:
               --base master \
               --head develop \
               --title "$TITLE" \
-              --body-file /tmp/pr-body.md
+              --body-file /tmp/pr-body.md \
+              --reviewer book000
           else
             gh pr edit "$EXISTING_PR" \
               --title "$TITLE" \
-              --body-file /tmp/pr-body.md
+              --body-file /tmp/pr-body.md \
+              --add-reviewer book000
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,6 @@ jobs:
         run: pnpm run lint
 
       - name: 🚀 Release
-        run: npx semantic-release
+        run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -25,7 +25,7 @@
     }],
     ["@semantic-release/release-notes-generator", { "preset": "conventionalcommits" }],
     ["@semantic-release/exec", {
-      "prepareCmd": "npm version --no-git-tag-version ${nextRelease.version} --prefix packages/core && npm version --no-git-tag-version ${nextRelease.version} --prefix packages/db-mysql",
+      "prepareCmd": "npm --prefix packages/core version --no-git-tag-version ${nextRelease.version} && npm --prefix packages/db-mysql version --no-git-tag-version ${nextRelease.version}",
       "publishCmd": "DIST_TAG=\"${nextRelease.channel || 'latest'}\" && pnpm --filter @book000/pixivts publish --access public --no-git-checks --ignore-scripts --tag \"$DIST_TAG\" && pnpm --filter @book000/pixivts-db-mysql publish --access public --no-git-checks --ignore-scripts --tag \"$DIST_TAG\""
     }],
     ["@semantic-release/github", { "successComment": false, "failComment": false }]


### PR DESCRIPTION
## Summary

Addresses Copilot review findings from PR #1671, plus one additional improvement.

## Changes

### 1. `.releaserc.json` — move `--prefix` before npm subcommand

```diff
- "prepareCmd": "npm version --no-git-tag-version ${nextRelease.version} --prefix packages/core && ..."
+ "prepareCmd": "npm --prefix packages/core version --no-git-tag-version ${nextRelease.version} && ..."
```

`--prefix` is a global npm config option; the canonical form places it before the subcommand to guarantee the correct `package.json` is targeted.

### 2. `release-pr.yml` — use `GH_TOKEN` for gh CLI

```diff
- GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+ GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

`GH_TOKEN` is the documented primary environment variable for the gh CLI. Both names are accepted, but `GH_TOKEN` is preferred.

### 3. `release.yml` — use `pnpm exec` instead of `npx`

```diff
- run: npx semantic-release
+ run: pnpm exec semantic-release
```

`pnpm exec` uses pnpm's binary resolution and is consistent with the rest of the workflow.

### 4. `release-pr.yml` — add book000 as reviewer on Release PR

```diff
  gh pr create \
    --base master \
    --head develop \
    --title "$TITLE" \
    --body-file /tmp/pr-body.md \
+   --reviewer book000
```

Ensures book000 is always assigned as a reviewer when the Release PR (develop → master) is created or updated.