### PR TITLE
ci: add workflow to enforce feature → develop → master PR flow

### DIFF
--- a/.github/workflows/enforce-pr-flow.yml
+++ b/.github/workflows/enforce-pr-flow.yml
@@ -1,0 +1,42 @@
+name: Enforce PR flow
+
+on:
+  pull_request_target:
+    # No branches filter — run on ALL PRs so this job also satisfies the
+    # required-status-check on the develop ruleset and does not deadlock
+    # feature → develop PRs.
+    # opened/reopened/synchronize: required by sync-repo-settings' "always-run"
+    # detection so this job is auto-registered as a required check.
+    # edited: captures base-branch retargeting.
+    types: [opened, reopened, synchronize, edited]
+
+# This check only reports a status (pass/fail); no repo access needed.
+permissions: {}
+
+jobs:
+  enforce-pr-flow:
+    # ⚠ This job name becomes the required-check context string.
+    # Do NOT rename after it has been registered — both rulesets would deadlock.
+    name: Enforce PR flow
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🚦 Require develop → master
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "$BASE_REF" != "master" ]; then
+            echo "Base is '$BASE_REF' (not master); flow check not applicable. ✅"
+            exit 0
+          fi
+          if [ "$HEAD_REF" != "develop" ] || [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::PRs into 'master' must come from this repository's 'develop' branch."
+            echo "Flow: feature/* → develop → master. Please retarget this PR to 'develop'."
+            echo "Current head: ${HEAD_REPO}:${HEAD_REF}"
+            exit 1
+          fi
+          echo "✅ Valid develop → master PR."

--- a/.github/workflows/enforce-pr-flow.yml
+++ b/.github/workflows/enforce-pr-flow.yml
@@ -2,12 +2,9 @@ name: Enforce PR flow
 
 on:
   pull_request_target:
-    # No branches filter — run on ALL PRs so this job also satisfies the
-    # required-status-check on the develop ruleset and does not deadlock
-    # feature → develop PRs.
-    # opened/reopened/synchronize: required by sync-repo-settings' "always-run"
-    # detection so this job is auto-registered as a required check.
-    # edited: captures base-branch retargeting.
+    # No branches filter: runs on all PRs so this job satisfies the develop
+    # ruleset's required check and does not deadlock feature → develop PRs.
+    # edited: also captures base-branch retargeting.
     types: [opened, reopened, synchronize, edited]
 
 # This check only reports a status (pass/fail); no repo access needed.


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow to enforce the `feature/* → develop → master` branch flow by blocking PRs that target `master` directly from any branch other than this repository's own `develop` branch.

## Problem

The `release-pr.yml` workflow auto-generates a `develop → master` PR for semantic-release to promote `@beta → @latest`. However, nothing prevented a contributor from targeting `master` directly, bypassing `develop` and breaking the release pipeline.

## Changes

- **New:** `.github/workflows/enforce-pr-flow.yml`
  - Runs on `pull_request_target` for all PRs (no `branches:` filter)
  - When `base == master`: fails unless `head == develop` from this repository (not a fork)
  - When `base != master`: exits 0 immediately — feature→develop PRs are never deadlocked
  - Uses env-var indirection for all `github.*` context values to prevent script injection
  - `HEAD_REPO == BASE_REPO` guard prevents a fork with a `develop` branch from spoofing the canonical source

## Why no `branches:` filter

`sync-repo-settings` auto-detects jobs with `opened`/`reopened`/`synchronize` in `types:` as "always-run" and registers them as required checks on **all** managed rulesets (both `develop` and `master`). A `branches: [master]` filter is ignored by the detector, so the job would be required on the `develop` ruleset but never execute there — permanently blocking every feature→develop PR. Running on all PRs with an in-step `base_ref` guard avoids this deadlock.