### PR TITLE
fix(ci): fix GitHub Pages deploy by calling from master context

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,27 +1,22 @@
-name: Deploy
+name: Deploy Docs
 
 on:
+  workflow_call:
   workflow_dispatch:
-  workflow_run:
-    # release:published does not fire when the release is created by GITHUB_TOKEN;
-    # workflow_run bypasses that restriction.
-    workflows: ["Release"]
-    types: [completed]
-    branches: [main, master]
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: 🛎 Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # Pin to the exact commit the Release workflow ran on so docs always
-          # match the tagged release. Falls back to github.ref for workflow_dispatch.
-          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: 🏗 Setup node
         uses: actions/setup-node@v6
@@ -65,7 +60,7 @@ jobs:
       - name: 📄 Generate API documentation
         run: pnpm --filter @book000/pixivts run generate-docs
 
-      - name: Upload Pages-artifact
+      - name: 📤 Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
           path: docs-out
@@ -81,6 +76,6 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - name: Deploy to GitHub Pages
+      - name: 🚀 Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,3 +84,12 @@ jobs:
         run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docs:
+    needs: release
+    if: ${{ github.ref == 'refs/heads/master' }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/deploy-docs.yml


### PR DESCRIPTION
## Summary

The default branch was changed from `master` to `develop` for the semantic-release beta channel. This broke GitHub Pages deployments because `workflow_run`-triggered workflows always execute in the **default branch** context (`develop`), while the `github-pages` environment only allows deployments from `master`.

As a result, every Pages deploy since the branch change has been rejected:
> Branch "develop" is not allowed to deploy to github-pages due to environment protection rules.

The public docs are stuck at **v0.59.4** while npm has **v0.60.1**.

## Root cause

1. Default branch = `develop` (changed ~2025-06-16).
2. `pages-deploy.yml` uses `workflow_run` → always runs in `develop` context.
3. `github-pages` environment policy only permits `master`.
4. Every Deploy attempt is rejected by the environment gate.

## Solution (Plan A — no environment policy changes)

Replace the `workflow_run` approach with a **reusable workflow** called directly from `release.yml` after the `release` job. When `release.yml` runs on a `master` push, the callee inherits the `master` ref and satisfies the environment protection policy. The environment policy (master-only) remains unchanged.

## Changes

| File | Action |
|------|--------|
| `.github/workflows/deploy-docs.yml` | **New** — reusable workflow (`workflow_call` + `workflow_dispatch`) that builds TypeDoc and deploys to GitHub Pages |
| `.github/workflows/release.yml` | **Edit** — add `docs` job (`needs: release`, master-only guard) that calls `deploy-docs.yml` |
| `.github/workflows/pages-deploy.yml` | **Deleted** — superseded by the above |

## Why not other approaches

- **Add `develop` to the environment policy**: lives outside the repo, invisible in git history, weakens the protection intent.
- **push trigger on master**: race condition — docs build may run before the release tag is created, causing the previous version to appear in the docs.