### PR TITLE
feat(core): make MetaSinglePage.originalImageUrl optional and add params to illustRecommended

### DIFF
--- a/packages/core/src/resources/illusts.ts
+++ b/packages/core/src/resources/illusts.ts
@@ -91,6 +91,24 @@ export interface IllustRecommendedParams {
    * value extracted from a previous page's `next_url` via {@link parseNextUrl}.
    */
   minBookmarkIdForRecentIllust?: number
+  /**
+   * Content type filter for recommended works.
+   * - `"illust"` — illustration works only
+   * - `"manga"` — manga works only
+   * Omit to receive both types.
+   */
+  contentType?: 'illust' | 'manga'
+  /**
+   * Whether to include ranking label information in the response.
+   * Defaults to `true` when omitted.
+   */
+  includeRankingLabel?: boolean
+  /**
+   * IDs of illusts already seen by the user.
+   * The API will exclude these from the recommendations.
+   * Serialised as repeated `viewed[]=<id>` query parameters.
+   */
+  viewed?: number[]
 }
 
 /** Parameters for fetching an illust series. */
@@ -259,12 +277,14 @@ export class IllustResource {
         '/v1/illust/recommended',
         buildParams({
           filter: params.filter ?? 'for_ios',
-          includeRankingLabel: true,
+          contentType: params.contentType,
+          includeRankingLabel: params.includeRankingLabel ?? true,
           includeRankingIllusts: true,
           includePrivacyPolicy: true,
           offset: params.offset,
           maxBookmarkIdForRecommend: params.maxBookmarkIdForRecommend,
           minBookmarkIdForRecentIllust: params.minBookmarkIdForRecentIllust,
+          ...(params.viewed ? { viewed: params.viewed } : {}),
         })
       ),
       this.#http,

--- a/packages/core/src/schemas/illust.ts
+++ b/packages/core/src/schemas/illust.ts
@@ -14,7 +14,7 @@ import {
 
 /** Single-page illust detail (originalImageUrl). */
 export const MetaSinglePageSchema = z.object({
-  originalImageUrl: z.string(),
+  originalImageUrl: z.string().optional(),
 })
 
 /** Multi-page illust detail (imageUrls for each page). */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -94,10 +94,18 @@ export interface PrivacyPolicy {
 // Illust
 // ---------------------------------------------------------------------------
 
-/** Original-image URL for a single-page illust. */
+/**
+ * Original-image URL for a single-page illust.
+ *
+ * For manga works the API returns `meta_single_page` as an empty object `{}`,
+ * so `originalImageUrl` may be absent even when the enclosing object is present.
+ */
 export interface MetaSinglePage {
-  /** Direct URL to the original-resolution image. */
-  originalImageUrl: string
+  /**
+   * Direct URL to the original-resolution image.
+   * Absent for manga works where `meta_single_page` is returned as `{}`.
+   */
+  originalImageUrl?: string
 }
 
 /** Per-page image URLs for a multi-page work (manga). */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -160,7 +160,7 @@ export interface PixivIllustItem {
   series: Series | null
   /**
    * For single-page works: `{ originalImageUrl: string }`.
-   * For multi-page works: `{}` (empty object).
+   * For multi-page works (manga): `{}` (empty object; `originalImageUrl` will be `undefined`).
    */
   metaSinglePage: MetaSinglePage | Record<string, never>
   /** Per-page image URLs for multi-page works (empty array for single-page). */

--- a/packages/core/tests/client.test.ts
+++ b/packages/core/tests/client.test.ts
@@ -235,6 +235,189 @@ describe('illusts.ranking()', () => {
   })
 })
 
+// ---------------------------------------------------------------------------
+// illusts.recommended() — unit tests (MSW)
+// ---------------------------------------------------------------------------
+
+const RECOMMENDED_RESPONSE = {
+  illusts: [ILLUST],
+  ranking_illusts: [] as unknown[],
+  contest_exists: false,
+  next_url: null,
+}
+
+describe('illusts.recommended() — default params', () => {
+  it('sends include_ranking_label=true by default', async () => {
+    let capturedUrl: string | undefined
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get(
+        'https://app-api.pixiv.net/v1/illust/recommended',
+        ({ request }) => {
+          capturedUrl = request.url
+          return HttpResponse.json(RECOMMENDED_RESPONSE)
+        }
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.illusts.recommended()
+    expect(result.isOk).toBe(true)
+    expect(capturedUrl).toBeDefined()
+    if (capturedUrl === undefined) return
+    const params = new URL(capturedUrl).searchParams
+    expect(params.get('include_ranking_label')).toBe('true')
+  })
+})
+
+describe('illusts.recommended() — contentType param', () => {
+  it('sends content_type when contentType is specified', async () => {
+    let capturedUrl: string | undefined
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get(
+        'https://app-api.pixiv.net/v1/illust/recommended',
+        ({ request }) => {
+          capturedUrl = request.url
+          return HttpResponse.json(RECOMMENDED_RESPONSE)
+        }
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    await client.illusts.recommended({ contentType: 'manga' })
+    expect(capturedUrl).toBeDefined()
+    if (capturedUrl === undefined) return
+    const params = new URL(capturedUrl).searchParams
+    expect(params.get('content_type')).toBe('manga')
+  })
+
+  it('omits content_type when contentType is not specified', async () => {
+    let capturedUrl: string | undefined
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get(
+        'https://app-api.pixiv.net/v1/illust/recommended',
+        ({ request }) => {
+          capturedUrl = request.url
+          return HttpResponse.json(RECOMMENDED_RESPONSE)
+        }
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    await client.illusts.recommended()
+    expect(capturedUrl).toBeDefined()
+    if (capturedUrl === undefined) return
+    const params = new URL(capturedUrl).searchParams
+    expect(params.has('content_type')).toBe(false)
+  })
+})
+
+describe('illusts.recommended() — includeRankingLabel param', () => {
+  it('sends include_ranking_label=false when explicitly set to false', async () => {
+    let capturedUrl: string | undefined
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get(
+        'https://app-api.pixiv.net/v1/illust/recommended',
+        ({ request }) => {
+          capturedUrl = request.url
+          return HttpResponse.json(RECOMMENDED_RESPONSE)
+        }
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    await client.illusts.recommended({ includeRankingLabel: false })
+    expect(capturedUrl).toBeDefined()
+    if (capturedUrl === undefined) return
+    const params = new URL(capturedUrl).searchParams
+    expect(params.get('include_ranking_label')).toBe('false')
+  })
+})
+
+describe('illusts.recommended() — viewed param', () => {
+  it('sends viewed[] for each ID when viewed is specified', async () => {
+    let capturedUrl: string | undefined
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get(
+        'https://app-api.pixiv.net/v1/illust/recommended',
+        ({ request }) => {
+          capturedUrl = request.url
+          return HttpResponse.json(RECOMMENDED_RESPONSE)
+        }
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    await client.illusts.recommended({ viewed: [101, 202] })
+    expect(capturedUrl).toBeDefined()
+    if (capturedUrl === undefined) return
+    const params = new URL(capturedUrl).searchParams
+    expect(params.getAll('viewed[]')).toEqual(['101', '202'])
+  })
+
+  it('omits viewed[] when viewed is not specified', async () => {
+    let capturedUrl: string | undefined
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get(
+        'https://app-api.pixiv.net/v1/illust/recommended',
+        ({ request }) => {
+          capturedUrl = request.url
+          return HttpResponse.json(RECOMMENDED_RESPONSE)
+        }
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    await client.illusts.recommended()
+    expect(capturedUrl).toBeDefined()
+    if (capturedUrl === undefined) return
+    const params = new URL(capturedUrl).searchParams
+    expect(params.has('viewed[]')).toBe(false)
+  })
+})
+
+describe('illusts.recommended() — meta_single_page regression (PIXIVTS-39)', () => {
+  it('handles meta_single_page as empty object without errors', async () => {
+    const MANGA_ILLUST = {
+      ...ILLUST,
+      type: 'manga' as const,
+      meta_single_page: {},
+    }
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get(
+        'https://app-api.pixiv.net/v1/illust/recommended',
+        () =>
+          HttpResponse.json({
+            ...RECOMMENDED_RESPONSE,
+            illusts: [MANGA_ILLUST],
+          })
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.illusts.recommended()
+    expect(result.isOk).toBe(true)
+    if (result.isOk) {
+      const illust = result.value.illusts[0]
+      expect(illust.type).toBe('manga')
+      expect(illust.metaSinglePage.originalImageUrl).toBeUndefined()
+    }
+  })
+})
+
 describe('illusts.bookmarkAdd()', () => {
   it('returns Ok', async () => {
     server.use(

--- a/packages/core/tests/client.test.ts
+++ b/packages/core/tests/client.test.ts
@@ -287,7 +287,8 @@ describe('illusts.recommended() — contentType param', () => {
       )
     )
     const client = await PixivClient.of('test-refresh-token')
-    await client.illusts.recommended({ contentType: 'manga' })
+    const result = await client.illusts.recommended({ contentType: 'manga' })
+    expect(result.isOk).toBe(true)
     expect(capturedUrl).toBeDefined()
     if (capturedUrl === undefined) return
     const params = new URL(capturedUrl).searchParams
@@ -309,7 +310,8 @@ describe('illusts.recommended() — contentType param', () => {
       )
     )
     const client = await PixivClient.of('test-refresh-token')
-    await client.illusts.recommended()
+    const result = await client.illusts.recommended()
+    expect(result.isOk).toBe(true)
     expect(capturedUrl).toBeDefined()
     if (capturedUrl === undefined) return
     const params = new URL(capturedUrl).searchParams
@@ -333,7 +335,8 @@ describe('illusts.recommended() — includeRankingLabel param', () => {
       )
     )
     const client = await PixivClient.of('test-refresh-token')
-    await client.illusts.recommended({ includeRankingLabel: false })
+    const result = await client.illusts.recommended({ includeRankingLabel: false })
+    expect(result.isOk).toBe(true)
     expect(capturedUrl).toBeDefined()
     if (capturedUrl === undefined) return
     const params = new URL(capturedUrl).searchParams
@@ -357,7 +360,8 @@ describe('illusts.recommended() — viewed param', () => {
       )
     )
     const client = await PixivClient.of('test-refresh-token')
-    await client.illusts.recommended({ viewed: [101, 202] })
+    const result = await client.illusts.recommended({ viewed: [101, 202] })
+    expect(result.isOk).toBe(true)
     expect(capturedUrl).toBeDefined()
     if (capturedUrl === undefined) return
     const params = new URL(capturedUrl).searchParams
@@ -379,7 +383,8 @@ describe('illusts.recommended() — viewed param', () => {
       )
     )
     const client = await PixivClient.of('test-refresh-token')
-    await client.illusts.recommended()
+    const result = await client.illusts.recommended()
+    expect(result.isOk).toBe(true)
     expect(capturedUrl).toBeDefined()
     if (capturedUrl === undefined) return
     const params = new URL(capturedUrl).searchParams


### PR DESCRIPTION
## Summary

Two non-breaking changes to the core library.

## Changes

### Fix: `MetaSinglePage.originalImageUrl` is now optional

The pixiv API returns `meta_single_page` as an empty object `{}` for manga works, meaning `originalImageUrl` can be absent even when the parent object is present. The field is now typed as `originalImageUrl?: string` (was `string`). The internal Zod schema is updated to match (`z.string().optional()`).

**Files:** `src/types.ts`, `src/schemas/illust.ts`

### Feat: New parameters for `IllustRecommendedParams` / `illusts.recommended()`

Three new optional parameters have been added to `IllustRecommendedParams`:

| Parameter | Type | Default | Description |
|---|---|---|---|
| `contentType` | `'illust' \| 'manga'` | — | Filter recommended works by type. Omit for both types. Serialised as `content_type`. |
| `includeRankingLabel` | `boolean` | `true` | Whether to include ranking label data. Was previously hard-coded to `true`; now caller-controlled while preserving the existing default. |
| `viewed` | `number[]` | — | IDs of already-seen illusts to exclude. Serialised as repeated `viewed[]=<id>` params (Rails bracket convention). |

**Files:** `src/resources/illusts.ts`, `tests/client.test.ts`

## Tests

MSW unit tests added for `illusts.recommended()`:
- `contentType` is sent as `content_type` in the wire
- `includeRankingLabel: false` is sent as `include_ranking_label=false`
- Default `include_ranking_label=true` when omitted
- `viewed` is sent as repeated `viewed[]` params; omitted when not specified
- Regression test: `meta_single_page: {}` (empty object) does not cause runtime errors and yields `metaSinglePage.originalImageUrl === undefined`

## Compatibility

All changes are backward-compatible:
- `originalImageUrl` becoming optional is a widening of the type, not a narrowing
- New `IllustRecommendedParams` fields are all optional
- `includeRankingLabel` still defaults to `true`, preserving the previous wire behaviour for existing callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)