### PR TITLE
ci(release-pr): use GH_PAT to trigger pull_request_target workflows

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -188,4 +188,4 @@ jobs:
               --add-reviewer book000
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -189,3 +189,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
+          # Explicitly clear GITHUB_TOKEN so gh CLI cannot fall back to it
+          # if GH_PAT is missing — the step will fail fast instead of
+          # silently using GITHUB_TOKEN (which would not trigger pull_request_target).
+          GITHUB_TOKEN: ""

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -189,7 +189,4 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
-          # Explicitly clear GITHUB_TOKEN so gh CLI cannot fall back to it
-          # if GH_PAT is missing — the step will fail fast instead of
-          # silently using GITHUB_TOKEN (which would not trigger pull_request_target).
-          GITHUB_TOKEN: ""
+          GITHUB_TOKEN: ""  # Prevent gh CLI fallback to GITHUB_TOKEN if GH_PAT is unset


### PR DESCRIPTION
## Summary

`release-pr.yml` was creating release PRs using `GITHUB_TOKEN`, which caused `check-pr-language` and `Enforce PR flow` required checks to never be triggered.

GitHub explicitly does not trigger workflow runs for events caused by `GITHUB_TOKEN`. Switching to a fine-grained PAT (`GH_PAT`, scoped to `book000/pixivts` with `pull-requests: write` only) ensures the `pull_request_target` event fires correctly and both required checks run as expected.

## Changes

- `.github/workflows/release-pr.yml`: replace `secrets.GITHUB_TOKEN` with `secrets.GH_PAT` in the `gh pr create` / `gh pr edit` step