### PR TITLE
ci: fix release workflow — back-merge, cancel-in-progress, beta tag range, CI dedup

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -7,7 +7,9 @@ on:
     branches:
       - main
       - master
-      - develop
+      # develop is intentionally excluded: every push to develop updates the
+      # develop→master Release PR, which fires pull_request_target:synchronize
+      # and runs CI via that event.  Including develop here would run CI twice.
   # Consolidate PR events to pull_request_target only (using both pull_request and
   # pull_request_target simultaneously can cause finished-node-ci's skipped result
   # to incorrectly pass required checks)

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -9,7 +9,6 @@ on:
       # develop is intentionally excluded: every push to develop updates the
       # develop→master Release PR, which fires pull_request_target:synchronize
       # and runs CI via that event.  Including develop here would run CI twice.
-      # main is intentionally excluded: this repo uses master as the default branch.
   # Consolidate PR events to pull_request_target only (using both pull_request and
   # pull_request_target simultaneously can cause finished-node-ci's skipped result
   # to incorrectly pass required checks)
@@ -20,7 +19,6 @@ on:
     branches:
       - master
       - develop
-      # main is intentionally excluded: this repo uses master as the default branch.
     types:
       - opened
       - synchronize

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -5,11 +5,11 @@ name: Node CI
 on:
   push:
     branches:
-      - main
       - master
       # develop is intentionally excluded: every push to develop updates the
       # develop→master Release PR, which fires pull_request_target:synchronize
       # and runs CI via that event.  Including develop here would run CI twice.
+      # main is intentionally excluded: this repo uses master as the default branch.
   # Consolidate PR events to pull_request_target only (using both pull_request and
   # pull_request_target simultaneously can cause finished-node-ci's skipped result
   # to incorrectly pass required checks)
@@ -18,9 +18,9 @@ on:
   # Fork PR:      blocked by the environment: fork-pr-build approval gate
   pull_request_target:
     branches:
-      - main
       - master
       - develop
+      # main is intentionally excluded: this repo uses master as the default branch.
     types:
       - opened
       - synchronize

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -9,6 +9,7 @@ on:
       # develop is intentionally excluded: every push to develop updates the
       # develop→master Release PR, which fires pull_request_target:synchronize
       # and runs CI via that event.  Including develop here would run CI twice.
+
   # Consolidate PR events to pull_request_target only (using both pull_request and
   # pull_request_target simultaneously can cause finished-node-ci's skipped result
   # to incorrectly pass required checks)

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,8 +10,10 @@ on:
       - develop
 
 concurrency:
+  # Do not cancel in-progress runs: a canceled run may have already created/updated
+  # the PR but not yet posted the Checks API runs, leaving required checks pending.
   group: release-pr
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   release-pr:
@@ -109,9 +111,19 @@ jobs:
             BUMP="patch"; NEXT="${MAJOR}.${MINOR}.$((PATCH+1))"
           fi
 
-          # --- Most recently created 5 beta tags (sorted by creation date, not version) ---
-          # Using -creatordate so backfilled or hotfix betas don't displace newer ones.
-          BETA_TAGS=$(git tag -l "v*-beta.*" --sort=-creatordate 2>/dev/null | head -5 || echo "")
+          # --- Beta tags for the current release cycle (since LAST_STABLE, on develop) ---
+          # Only include beta tags whose commit is a descendant of LAST_STABLE AND an
+          # ancestor of HEAD, so stale betas from prior cycles are excluded.
+          # Sorted by creation date (newest first), capped at 5 entries.
+          BETA_TAGS=""
+          while IFS= read -r tag; do
+            tag_commit=$(git rev-list -n 1 "${tag}" 2>/dev/null) || continue
+            if git merge-base --is-ancestor "${LAST_STABLE}" "${tag_commit}" 2>/dev/null && \
+               git merge-base --is-ancestor "${tag_commit}" HEAD 2>/dev/null; then
+              BETA_TAGS="${BETA_TAGS}${tag}"$'\n'
+            fi
+          done < <(git tag -l "v*-beta.*" --sort=-creatordate 2>/dev/null | head -20)
+          BETA_TAGS=$(printf '%s' "$BETA_TAGS" | head -5)
 
           # --- Build PR body to a temp file (avoids quoting pitfalls) ---
           {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Release
 on:
   push:
     branches:
-      - main
       - master
       - develop
 
@@ -84,6 +83,30 @@ jobs:
         run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🔀 Back-merge master into develop
+        # Run only after a stable release (master push) so that the release tag
+        # enters develop's ancestry — required for semantic-release to start a
+        # fresh pre-release cycle with the correct next version (e.g. v0.61.0-beta.1).
+        # Uses DEPLOY_KEY (SSH deploy key with write access) to push to the protected
+        # develop branch.  Configure it in repo Settings → Deploy keys and add it as
+        # a bypass actor in the develop branch ruleset.
+        if: github.ref == 'refs/heads/master'
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          git config core.sshCommand "ssh -i ~/.ssh/deploy_key -F /dev/null"
+          git remote set-url origin git@github.com:${{ github.repository }}.git
+          # After the Release PR is merged, master's merge commit has develop HEAD as
+          # a parent, so pushing master HEAD to develop is always a valid fast-forward
+          # in the normal workflow.  If develop has diverged due to a concurrent push,
+          # this push fails — resolve manually by merging master into develop.
+          git fetch origin develop
+          git push origin HEAD:refs/heads/develop
+          rm -f ~/.ssh/deploy_key
 
   docs:
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,6 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          # Ensure the deploy key is removed on all exit paths (success, error, or signal).
           trap 'rm -f ~/.ssh/deploy_key' EXIT
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
           git config core.sshCommand "ssh -i ~/.ssh/deploy_key -F /dev/null"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,8 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
+          # Ensure the deploy key is removed on all exit paths (success, error, or signal).
+          trap 'rm -f ~/.ssh/deploy_key' EXIT
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
           git config core.sshCommand "ssh -i ~/.ssh/deploy_key -F /dev/null"
           git remote set-url origin git@github.com:${{ github.repository }}.git
@@ -106,7 +108,6 @@ jobs:
           # this push fails — resolve manually by merging master into develop.
           git fetch origin develop
           git push origin HEAD:refs/heads/develop
-          rm -f ~/.ssh/deploy_key
 
   docs:
     needs: release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,6 @@
 {
   "branches": [
     "master",
-    "main",
     { "name": "develop", "prerelease": "beta", "channel": "beta" }
   ],
   "tagFormat": "v${version}",


### PR DESCRIPTION
## Summary

Fix five issues in the release/CI workflow configuration identified during a review
of the feature→develop→master branch strategy with semantic-release.

## Changes

### 1. Back-merge master → develop after stable release (`release.yml`)

**Problem:** After a stable release (develop→master PR merge), the release tag is placed
on master's merge commit, which is not in develop's ancestry.
`semantic-release` uses `git tag --merged develop` to determine the last release, so
it cannot see the stable tag. All subsequent beta releases increment as
`v0.X.Y-beta.N+1` indefinitely instead of starting a fresh cycle (e.g.
`v0.61.0-beta.1`).

**Fix:** Add a back-merge step to `release.yml` that fast-forwards develop to master's
HEAD after each stable release, using an SSH deploy key (`DEPLOY_KEY` secret) to
bypass develop branch protection.

> **Required setup:** Add the deploy key's public key in repo Settings → Deploy keys
> (write access) and register it as a bypass actor in the develop branch ruleset.

### 2. `cancel-in-progress: false` in `release-pr.yml`

**Problem:** With `cancel-in-progress: true`, a concurrent push could cancel a run
that had already created/updated the PR but had not yet posted the Checks API runs,
leaving required checks in a pending state and blocking the Release PR indefinitely.

**Fix:** Set `cancel-in-progress: false` so in-progress runs complete before a new
run starts.

### 3. BETA_TAGS filtered to the current release cycle (`release-pr.yml`)

**Problem:** The "Beta releases tested" section used the 5 most recently *created* beta
tags globally, including stale betas from prior cycles (e.g. `v0.60.0-beta.*` still
appeared in the body of a `v0.61.0` Release PR).

**Fix:** Filter to beta tags whose commit is a descendant of `LAST_STABLE` and an
ancestor of `HEAD`, matching only the current cycle's betas.

### 4. Remove `develop` from the `push` trigger in `nodejs-ci.yml`

**Problem:** Every push to develop triggers `release-pr.yml`, which updates the
develop→master Release PR, which fires `pull_request_target:synchronize` — running CI
a second time with a different concurrency group and doubling CI cost.

**Fix:** Remove `develop` from the `push:` trigger. CI runs once per push via the PR
synchronize event.

### 5. Remove dead `main` branch references

**Problem:** `main` does not exist in this repository but appears in both
`release.yml` push triggers and the `branches` array in `.releaserc.json`.

**Fix:** Remove both references.