### PR TITLE
fix(lint): resolve unicorn ruleset violations ahead of eslint-config bump

### DIFF
--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -24,28 +24,28 @@ export interface AuthCredentials {
 // ---------------------------------------------------------------------------
 
 // Per-round constants derived from sin (Table T in RFC 1321)
-const T: number[] = Array.from({ length: 64 }, (_, i) =>
-  Math.floor(Math.abs(Math.sin(i + 1)) * 2 ** 32)
+const T: number[] = Array.from({ length: 64 }, (_, index) =>
+  Math.floor(Math.abs(Math.sin(index + 1)) * 2 ** 32)
 )
 
 // Shift amounts per round
 const S = [
   7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 5, 9, 14, 20, 5,
   9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11,
-  16, 23, 4, 11, 16, 23, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10,
-  15, 21,
+  16, 23, 4, 11, 16, 23, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15,
+  21,
 ]
 
 function md5Bytes(bytes: number[]): string {
-  const len = bytes.length
+  const length = bytes.length
   // Append bit 1 (0x80 byte)
   bytes.push(0x80)
   // Pad to 56 mod 64 bytes
   while (bytes.length % 64 !== 56) bytes.push(0)
   // Append original length in bits as little-endian 64-bit
-  const bitLen = len * 8
-  for (let i = 0; i < 8; i++) {
-    bytes.push(i < 4 ? (bitLen >>> (i * 8)) & 0xff : 0)
+  const bitLength = length * 8
+  for (let index = 0; index < 8; index++) {
+    bytes.push(index < 4 ? (bitLength >>> (index * 8)) & 0xff : 0)
   }
 
   // Initial hash state
@@ -73,30 +73,30 @@ function md5Bytes(bytes: number[]): string {
     let cc = c
     let dd = d
 
-    for (let i = 0; i < 64; i++) {
+    for (let index = 0; index < 64; index++) {
       let f: number
       let g: number
-      if (i < 16) {
+      if (index < 16) {
         f = (bb & cc) | (~bb & dd)
-        g = i
-      } else if (i < 32) {
+        g = index
+      } else if (index < 32) {
         f = (dd & bb) | (~dd & cc)
-        g = (5 * i + 1) % 16
-      } else if (i < 48) {
+        g = (5 * index + 1) % 16
+      } else if (index < 48) {
         f = bb ^ cc ^ dd
-        g = (3 * i + 5) % 16
+        g = (3 * index + 5) % 16
       } else {
         f = cc ^ (bb | ~dd)
-        g = (7 * i) % 16
+        g = (7 * index) % 16
       }
 
-      const tmp = dd
+      const temporary = dd
       dd = cc
       cc = bb
-      const sum = Math.trunc(aa + f + M[g] + T[i])
-      const rotated = (sum << S[i]) | (sum >>> (32 - S[i]))
+      const sum = Math.trunc(aa + f + M[g] + T[index])
+      const rotated = (sum << S[index]) | (sum >>> (32 - S[index]))
       bb = Math.trunc(bb + rotated)
-      aa = tmp
+      aa = temporary
     }
 
     a = Math.trunc(a + aa)
@@ -127,8 +127,8 @@ function md5Bytes(bytes: number[]): string {
 export function md5(input: string): string {
   // Encode the input string as a sequence of bytes (UTF-8)
   const bytes: number[] = []
-  for (let i = 0; i < input.length; i++) {
-    const code = input.codePointAt(i) ?? 0
+  for (let index = 0; index < input.length; index++) {
+    const code = input.codePointAt(index) ?? 0
     if (code < 0x80) {
       bytes.push(code)
     } else if (code < 0x8_00) {
@@ -144,7 +144,6 @@ export function md5(input: string): string {
 
   return md5Bytes(bytes)
 }
-
 
 // ---------------------------------------------------------------------------
 // AuthManager
@@ -222,9 +221,7 @@ export class AuthManager {
     })
 
     if (response.status !== 200) {
-      throw new Error(
-        `Failed to refresh pixiv token: HTTP ${response.status}`
-      )
+      throw new Error(`Failed to refresh pixiv token: HTTP ${response.status}`)
     }
 
     const data = (await response.json()) as {

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -9,11 +9,16 @@
  */
 
 import type { AuthManager } from './auth'
-import { apiError, authFailedError, networkError, rateLimitError } from './errors'
+import {
+  apiError,
+  authFailedError,
+  networkError,
+  rateLimitError,
+} from './errors'
 import type { ResponseInterceptor } from './interceptor'
 import { type HttpMethod, type ResponseRecord } from './interceptor'
-import { camelizeKeys } from './params'
-import { err, ok, ResultAsync } from './result'
+import { camelizeKeys } from './parameters'
+import { err as error, ok, ResultAsync } from './result'
 import type { PixivError } from './errors'
 import type { Result } from './result'
 
@@ -73,7 +78,7 @@ export function parseRetryAfter(
 
   // delay-seconds format
   if (/^\d+$/.test(retryAfter.trim())) {
-    return Number.parseInt(retryAfter, 10) * 1000
+    return Number(retryAfter) * 1000
   }
 
   // HTTP-date format (e.g. "Wed, 21 Oct 2026 07:28:00 GMT")
@@ -86,10 +91,7 @@ export function parseRetryAfter(
 }
 
 function headersToRecord(headers: Headers): Record<string, string> {
-  const result: Record<string, string> = {}
-  for (const [key, value] of headers) {
-    result[key] = value
-  }
+  const result: Record<string, string> = Object.fromEntries(headers)
   return result
 }
 
@@ -123,11 +125,14 @@ export class HttpClient {
    * Sends a GET request to the pixiv API.
    *
    * @param path - API endpoint path (e.g. "/v1/illust/detail")
-   * @param params - Query parameters as a URLSearchParams instance
+   * @param parameters - Query parameters as a URLSearchParams instance
    * @returns `ResultAsync<T, PixivError>`
    */
-  get<T>(path: string, params?: URLSearchParams): ResultAsync<T, PixivError> {
-    const qs = params ? `?${params.toString()}` : ''
+  get<T>(
+    path: string,
+    parameters?: URLSearchParams
+  ): ResultAsync<T, PixivError> {
+    const qs = parameters ? `?${parameters.toString()}` : ''
     const url = `${BASE_URL}${path}${qs}`
     return this.#send<T>(url, 'GET', path, undefined)
   }
@@ -165,11 +170,11 @@ export class HttpClient {
       networkError
     ).andThen((response) => {
       if (!response.ok) {
-        return ResultAsync.fromResult(
-          err(apiError(response.status, null))
-        )
+        return ResultAsync.fromResult(error(apiError(response.status, null)))
       }
-      return ResultAsync.fromResult(ok(response) as Result<Response, PixivError>)
+      return ResultAsync.fromResult(
+        ok(response) as Result<Response, PixivError>
+      )
     })
   }
 
@@ -210,7 +215,7 @@ export class HttpClient {
     method: HttpMethod,
     endpoint: string,
     body: string | undefined,
-    allowRefresh = true
+    shouldAllowRefresh = true
   ): Promise<Result<T, PixivError>> {
     const maxRetries = Math.max(0, this.#retry.maxRetries)
     const waitMs = Math.max(0, this.#retry.waitMs)
@@ -221,9 +226,9 @@ export class HttpClient {
       const requestHeaders: Record<string, string> = {
         ...DEFAULT_HEADERS,
         Authorization: `Bearer ${this.#auth.accessToken}`,
-        ...(method === 'POST'
-          ? { 'Content-Type': 'application/x-www-form-urlencoded' }
-          : {}),
+        ...(method === 'POST' && {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        }),
       }
 
       let response: Response
@@ -234,7 +239,7 @@ export class HttpClient {
           body: method === 'POST' ? body : undefined,
         })
       } catch (fetchError: unknown) {
-        return err(networkError(fetchError))
+        return error(networkError(fetchError))
       }
 
       // 429 Rate limit
@@ -251,22 +256,22 @@ export class HttpClient {
           continue
         }
 
-        return err(rateLimitError(lastRetryAfterMs))
+        return error(rateLimitError(lastRetryAfterMs))
       }
 
       // 401 Auth failed → try token refresh once
       if (response.status === 401) {
         await response.body?.cancel()
-        if (allowRefresh) {
+        if (shouldAllowRefresh) {
           try {
             await this.#auth.refresh()
           } catch {
-            return err(authFailedError(401))
+            return error(authFailedError(401))
           }
           // Retry once with the new token (no further refresh allowed)
           return this.#sendWithRetry<T>(url, method, endpoint, body, false)
         }
-        return err(authFailedError(401))
+        return error(authFailedError(401))
       }
 
       // Parse response body
@@ -288,7 +293,7 @@ export class HttpClient {
 
       // Non-2xx errors
       if (!response.ok) {
-        return err(apiError(response.status, data))
+        return error(apiError(response.status, data))
       }
 
       const httpResponse: HttpResponse<T> = {
@@ -314,12 +319,14 @@ export class HttpClient {
           responseHeaders: JSON.stringify(responseHeaders),
           responseBody: text,
         }
-        Promise.resolve(this.#interceptor(record)).catch(() => undefined)
+        Promise.resolve(this.#interceptor(record)).catch(() => {
+          // Interceptor errors must not fail the request (fire-and-forget).
+        })
       }
 
       return ok(httpResponse.data)
     }
 
-    return err(rateLimitError(lastRetryAfterMs))
+    return error(rateLimitError(lastRetryAfterMs))
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,22 +13,34 @@
 
 // Result primitives
 export { ok, err, ResultAsync } from './result'
-export type { Result, OkResult, ErrResult } from './result'
+export type { Result, OkResult, ErrorResult } from './result'
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- re-exporting the deprecated alias itself for backward compatibility, not using it
+export type { ErrResult } from './result'
 
 // Pagination
 export { PaginatedResultAsync, failedPaginated } from './paginated'
 export type { PagedResponse } from './paginated'
 
 // URL utilities
-export { parseNextUrl } from './params'
-export type { ParsedNextUrl } from './params'
+export { parseNextUrl } from './parameters'
+export type { ParsedNextUrl } from './parameters'
 
 // Error types
-export { rateLimitError, authFailedError, networkError, apiError, PixivFetchError } from './errors'
+export {
+  rateLimitError,
+  authFailedError,
+  networkError,
+  apiError,
+  PixivFetchError,
+} from './errors'
 export type { PixivError } from './errors'
 
 // Interceptor (DB seam)
-export type { ResponseRecord, ResponseInterceptor, HttpMethod } from './interceptor'
+export type {
+  ResponseRecord,
+  ResponseInterceptor,
+  HttpMethod,
+} from './interceptor'
 
 // Option constants and types (exported as values so callers can use e.g. BookmarkRestrict.PUBLIC)
 export {
@@ -87,37 +99,74 @@ export type {
 
 // Resource param types
 export type {
-  IllustDetailParams,
-  IllustRelatedParams,
-  IllustSearchParams,
-  IllustRankingParams,
-  IllustRecommendedParams,
-  IllustSeriesParams,
-  IllustBookmarkAddParams,
-  IllustBookmarkDeleteParams,
+  IllustDetailParameters,
+  IllustRelatedParameters,
+  IllustSearchParameters,
+  IllustRankingParameters,
+  IllustRecommendedParameters,
+  IllustSeriesParameters,
+  IllustBookmarkAddParameters,
+  IllustBookmarkDeleteParameters,
 } from './resources/illusts'
 
 export type {
-  NovelDetailParams,
-  NovelTextParams,
-  NovelRelatedParams,
-  NovelSearchParams,
-  NovelRankingParams,
-  NovelRecommendedParams,
-  NovelSeriesParams,
-  NovelBookmarkAddParams,
-  NovelBookmarkDeleteParams,
+  NovelDetailParameters,
+  NovelTextParameters,
+  NovelRelatedParameters,
+  NovelSearchParameters,
+  NovelRankingParameters,
+  NovelRecommendedParameters,
+  NovelSeriesParameters,
+  NovelBookmarkAddParameters,
+  NovelBookmarkDeleteParameters,
 } from './resources/novels'
 
 export type {
-  UserBookmarksIllustParams,
-  UserBookmarksNovelParams,
-  UserDetailParams,
-  UserIllustsParams,
-  UserNovelsParams,
-  UserFollowingParams,
-  UserFollowAddParams,
-  UserFollowDeleteParams,
+  UserBookmarksIllustParameters,
+  UserBookmarksNovelParameters,
+  UserDetailParameters,
+  UserIllustsParameters,
+  UserNovelsParameters,
+  UserFollowingParameters,
+  UserFollowAddParameters,
+  UserFollowDeleteParameters,
+} from './resources/users'
+
+// Deprecated aliases for the resource param types above, kept for backward
+// compatibility with the pre-1.x `*Params` naming (renamed to `*Parameters`
+// to satisfy the `unicorn/name-replacements` lint rule).
+export type {
+  IllustDetailParameters as IllustDetailParams,
+  IllustRelatedParameters as IllustRelatedParams,
+  IllustSearchParameters as IllustSearchParams,
+  IllustRankingParameters as IllustRankingParams,
+  IllustRecommendedParameters as IllustRecommendedParams,
+  IllustSeriesParameters as IllustSeriesParams,
+  IllustBookmarkAddParameters as IllustBookmarkAddParams,
+  IllustBookmarkDeleteParameters as IllustBookmarkDeleteParams,
+} from './resources/illusts'
+
+export type {
+  NovelDetailParameters as NovelDetailParams,
+  NovelTextParameters as NovelTextParams,
+  NovelRelatedParameters as NovelRelatedParams,
+  NovelSearchParameters as NovelSearchParams,
+  NovelRankingParameters as NovelRankingParams,
+  NovelRecommendedParameters as NovelRecommendedParams,
+  NovelSeriesParameters as NovelSeriesParams,
+  NovelBookmarkAddParameters as NovelBookmarkAddParams,
+  NovelBookmarkDeleteParameters as NovelBookmarkDeleteParams,
+} from './resources/novels'
+
+export type {
+  UserBookmarksIllustParameters as UserBookmarksIllustParams,
+  UserBookmarksNovelParameters as UserBookmarksNovelParams,
+  UserDetailParameters as UserDetailParams,
+  UserIllustsParameters as UserIllustsParams,
+  UserNovelsParameters as UserNovelsParams,
+  UserFollowingParameters as UserFollowingParams,
+  UserFollowAddParameters as UserFollowAddParams,
+  UserFollowDeleteParameters as UserFollowDeleteParams,
 } from './resources/users'
 
 // PixivClient

--- a/packages/core/src/paginated.ts
+++ b/packages/core/src/paginated.ts
@@ -14,7 +14,7 @@
 import type { HttpClient } from './http'
 import type { PixivError } from './errors'
 import { PixivFetchError } from './errors'
-import { err } from './result'
+import { err as error_ } from './result'
 import type { Result } from './result'
 import { ResultAsync } from './result'
 
@@ -132,7 +132,7 @@ export function failedPaginated<TPage extends PagedResponse, TItem>(
   getItems: (page: TPage) => TItem[]
 ): PaginatedResultAsync<TPage, TItem> {
   return new PaginatedResultAsync(
-    Promise.resolve(err(error)),
+    Promise.resolve(error_(error)),
     http,
     getItems
   )

--- a/packages/core/src/parameters.ts
+++ b/packages/core/src/parameters.ts
@@ -25,18 +25,18 @@ export function camelToSnake(key: string): string {
  *
  * Values are preserved as-is; nested objects are NOT recursed into.
  *
- * @param obj - Object with camelCase keys
+ * @param object - Object with camelCase keys
  * @returns New object with snake_case keys
  */
-export function toSnakeKeys(obj: Record<string, unknown>): Record<string, unknown> {
+export function toSnakeKeys(object: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {}
-  for (const key of Object.keys(obj)) {
-    out[camelToSnake(key)] = obj[key]
+  for (const [key, value] of Object.entries(object)) {
+    out[camelToSnake(key)] = value
   }
   return out
 }
 
-type ParamValue =
+type ParameterValue =
   | string
   | number
   | boolean
@@ -54,14 +54,14 @@ type ParamValue =
  * - Booleans are serialised as `'true'` / `'false'`.
  * - Numbers are serialised via `.toString()`.
  *
- * @param params - Key/value pairs to serialise
+ * @param parameters - Key/value pairs to serialise
  * @returns Populated `URLSearchParams`
  */
-export function buildSearchParams(
-  params: Record<string, ParamValue>
+export function buildSearchParameters(
+  parameters: Record<string, ParameterValue>
 ): URLSearchParams {
   const usp = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
+  for (const [key, value] of Object.entries(parameters)) {
     if (value === null || value === undefined) continue
     if (Array.isArray(value)) {
       // The pixiv API (Rails backend) expects bracket-suffixed keys for arrays:
@@ -79,13 +79,15 @@ export function buildSearchParams(
  *
  * Convenience wrapper used by resource methods.
  *
- * @param params - camelCase record
+ * @param parameters - camelCase record
  * @returns Populated `URLSearchParams` with snake_case keys
  */
-export function buildParams(
-  params: Record<string, ParamValue>
+export function buildParameters(
+  parameters: Record<string, ParameterValue>
 ): URLSearchParams {
-  return buildSearchParams(toSnakeKeys(params) as Record<string, ParamValue>)
+  return buildSearchParameters(
+    toSnakeKeys(parameters) as Record<string, ParameterValue>
+  )
 }
 
 /**
@@ -184,28 +186,28 @@ export function parseNextUrl(url: string): ParsedNextUrl {
   const usp = new URL(url).searchParams
   const result: ParsedNextUrl = {}
 
-  const toNum = (key: string): number | undefined => {
+  const toNumber = (key: string): number | undefined => {
     const v = usp.get(key)
     if (v === null || v === '') return undefined
     const n = Number(v)
     return Number.isNaN(n) ? undefined : n
   }
 
-  const maxBookmarkId = toNum('max_bookmark_id')
+  const maxBookmarkId = toNumber('max_bookmark_id')
   if (maxBookmarkId !== undefined) result.maxBookmarkId = maxBookmarkId
 
-  const maxBookmarkIdForRecommend = toNum('max_bookmark_id_for_recommend')
+  const maxBookmarkIdForRecommend = toNumber('max_bookmark_id_for_recommend')
   if (maxBookmarkIdForRecommend !== undefined)
     result.maxBookmarkIdForRecommend = maxBookmarkIdForRecommend
 
-  const minBookmarkIdForRecentIllust = toNum('min_bookmark_id_for_recent_illust')
+  const minBookmarkIdForRecentIllust = toNumber('min_bookmark_id_for_recent_illust')
   if (minBookmarkIdForRecentIllust !== undefined)
     result.minBookmarkIdForRecentIllust = minBookmarkIdForRecentIllust
 
-  const offset = toNum('offset')
+  const offset = toNumber('offset')
   if (offset !== undefined) result.offset = offset
 
-  const lastOrder = toNum('last_order')
+  const lastOrder = toNumber('last_order')
   if (lastOrder !== undefined) result.lastOrder = lastOrder
 
   return result

--- a/packages/core/src/resources/illusts.ts
+++ b/packages/core/src/resources/illusts.ts
@@ -3,7 +3,7 @@
  */
 import type { HttpClient } from '../http'
 import type { PixivError } from '../errors'
-import { buildParams } from '../params'
+import { buildParameters } from '../parameters'
 import { PaginatedResultAsync } from '../paginated'
 import type { ResultAsync } from '../result'
 import {
@@ -24,7 +24,7 @@ import type {
 // === Request param types ===
 
 /** Parameters for fetching a single illust by ID. */
-export interface IllustDetailParams {
+export interface IllustDetailParameters {
   /** ID of the illust to fetch. */
   illustId: number
   /** OS filter to apply (default: `"for_ios"`). */
@@ -32,7 +32,7 @@ export interface IllustDetailParams {
 }
 
 /** Parameters for fetching related illusts. */
-export interface IllustRelatedParams {
+export interface IllustRelatedParameters {
   /** ID of the illust for which to fetch related works. */
   illustId: number
   /** Additional seed illust IDs to influence recommendations. */
@@ -42,7 +42,7 @@ export interface IllustRelatedParams {
 }
 
 /** Parameters for searching illusts. */
-export interface IllustSearchParams {
+export interface IllustSearchParameters {
   /** Search keyword. */
   word: string
   /** How to match the keyword against works (default: `"partial_match_for_tags"`). */
@@ -64,7 +64,7 @@ export interface IllustSearchParams {
 }
 
 /** Parameters for fetching the illust ranking. */
-export interface IllustRankingParams {
+export interface IllustRankingParameters {
   /** Ranking category (default: `"day"`). */
   mode?: (typeof RankingMode)[keyof typeof RankingMode]
   /** OS filter to apply (default: `"for_ios"`). */
@@ -76,7 +76,7 @@ export interface IllustRankingParams {
 }
 
 /** Parameters for fetching recommended illusts. */
-export interface IllustRecommendedParams {
+export interface IllustRecommendedParameters {
   /** OS filter to apply (default: `"for_ios"`). */
   filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Zero-based offset for pagination. */
@@ -112,7 +112,7 @@ export interface IllustRecommendedParams {
 }
 
 /** Parameters for fetching an illust series. */
-export interface IllustSeriesParams {
+export interface IllustSeriesParameters {
   /** ID of the illust series to fetch. */
   illustSeriesId: number
   /** OS filter to apply (default: `"for_ios"`). */
@@ -120,7 +120,7 @@ export interface IllustSeriesParams {
 }
 
 /** Parameters for adding an illust bookmark. */
-export interface IllustBookmarkAddParams {
+export interface IllustBookmarkAddParameters {
   /** ID of the illust to bookmark. */
   illustId: number
   /** Bookmark visibility (default: `"public"`). */
@@ -130,7 +130,7 @@ export interface IllustBookmarkAddParams {
 }
 
 /** Parameters for removing an illust bookmark. */
-export interface IllustBookmarkDeleteParams {
+export interface IllustBookmarkDeleteParameters {
   /** ID of the illust to remove from bookmarks. */
   illustId: number
 }
@@ -147,7 +147,7 @@ export class IllustResource {
    * Fetches a single illust by ID.
    * GET /v1/illust/detail
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    *
    * @example
    * ```ts
@@ -160,11 +160,14 @@ export class IllustResource {
    * ```
    */
   detail(
-    params: IllustDetailParams
+    parameters: IllustDetailParameters
   ): ResultAsync<IllustDetailResponse, PixivError> {
     return this.#http.get<IllustDetailResponse>(
       '/v1/illust/detail',
-      buildParams({ illustId: params.illustId, filter: params.filter ?? 'for_ios' })
+      buildParameters({
+        illustId: parameters.illustId,
+        filter: parameters.filter ?? 'for_ios',
+      })
     )
   }
 
@@ -172,20 +175,20 @@ export class IllustResource {
    * Fetches related illusts for a given illust.
    * GET /v2/illust/related
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   related(
-    params: IllustRelatedParams
+    parameters: IllustRelatedParameters
   ): PaginatedResultAsync<IllustListPage, IllustListPage['illusts'][number]> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<IllustListPage>(
         '/v2/illust/related',
-        buildParams({
-          illustId: params.illustId,
-          filter: params.filter ?? 'for_ios',
-          ...(params.seedIllustIds
-            ? { seedIllustIds: params.seedIllustIds }
-            : {}),
+        buildParameters({
+          illustId: parameters.illustId,
+          filter: parameters.filter ?? 'for_ios',
+          ...(parameters.seedIllustIds && {
+            seedIllustIds: parameters.seedIllustIds,
+          }),
         })
       ),
       this.#http,
@@ -197,7 +200,7 @@ export class IllustResource {
    * Searches for illusts.
    * GET /v1/search/illust
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    *
    * @example
    * ```ts
@@ -214,21 +217,21 @@ export class IllustResource {
    * ```
    */
   search(
-    params: IllustSearchParams
+    parameters: IllustSearchParameters
   ): PaginatedResultAsync<IllustListPage, IllustListPage['illusts'][number]> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<IllustListPage>(
         '/v1/search/illust',
-        buildParams({
-          word: params.word,
-          searchTarget: params.searchTarget ?? 'partial_match_for_tags',
-          sort: params.sort ?? 'date_desc',
-          filter: params.filter ?? 'for_ios',
-          duration: params.duration,
-          startDate: params.startDate,
-          endDate: params.endDate,
-          searchAiType: params.searchAiType,
-          offset: params.offset,
+        buildParameters({
+          word: parameters.word,
+          searchTarget: parameters.searchTarget ?? 'partial_match_for_tags',
+          sort: parameters.sort ?? 'date_desc',
+          filter: parameters.filter ?? 'for_ios',
+          duration: parameters.duration,
+          startDate: parameters.startDate,
+          endDate: parameters.endDate,
+          searchAiType: parameters.searchAiType,
+          offset: parameters.offset,
         })
       ),
       this.#http,
@@ -240,19 +243,19 @@ export class IllustResource {
    * Fetches the illust ranking.
    * GET /v1/illust/ranking
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   ranking(
-    params: IllustRankingParams = {}
+    parameters: IllustRankingParameters = {}
   ): PaginatedResultAsync<IllustListPage, IllustListPage['illusts'][number]> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<IllustListPage>(
         '/v1/illust/ranking',
-        buildParams({
-          mode: params.mode ?? 'day',
-          filter: params.filter ?? 'for_ios',
-          date: params.date,
-          offset: params.offset,
+        buildParameters({
+          mode: parameters.mode ?? 'day',
+          filter: parameters.filter ?? 'for_ios',
+          date: parameters.date,
+          offset: parameters.offset,
         })
       ),
       this.#http,
@@ -264,10 +267,10 @@ export class IllustResource {
    * Fetches recommended illusts.
    * GET /v1/illust/recommended
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   recommended(
-    params: IllustRecommendedParams = {}
+    parameters: IllustRecommendedParameters = {}
   ): PaginatedResultAsync<
     IllustRecommendedPage,
     IllustRecommendedPage['illusts'][number]
@@ -275,16 +278,16 @@ export class IllustResource {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<IllustRecommendedPage>(
         '/v1/illust/recommended',
-        buildParams({
-          filter: params.filter ?? 'for_ios',
-          contentType: params.contentType,
-          includeRankingLabel: params.includeRankingLabel ?? true,
+        buildParameters({
+          filter: parameters.filter ?? 'for_ios',
+          contentType: parameters.contentType,
+          includeRankingLabel: parameters.includeRankingLabel ?? true,
           includeRankingIllusts: true,
           includePrivacyPolicy: true,
-          offset: params.offset,
-          maxBookmarkIdForRecommend: params.maxBookmarkIdForRecommend,
-          minBookmarkIdForRecentIllust: params.minBookmarkIdForRecentIllust,
-          ...(params.viewed ? { viewed: params.viewed } : {}),
+          offset: parameters.offset,
+          maxBookmarkIdForRecommend: parameters.maxBookmarkIdForRecommend,
+          minBookmarkIdForRecentIllust: parameters.minBookmarkIdForRecentIllust,
+          ...(parameters.viewed && { viewed: parameters.viewed }),
         })
       ),
       this.#http,
@@ -296,10 +299,10 @@ export class IllustResource {
    * Fetches an illust series.
    * GET /v1/illust/series
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   series(
-    params: IllustSeriesParams
+    parameters: IllustSeriesParameters
   ): PaginatedResultAsync<
     IllustSeriesPage,
     IllustSeriesPage['illusts'][number]
@@ -307,9 +310,9 @@ export class IllustResource {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<IllustSeriesPage>(
         '/v1/illust/series',
-        buildParams({
-          illustSeriesId: params.illustSeriesId,
-          filter: params.filter ?? 'for_ios',
+        buildParameters({
+          illustSeriesId: parameters.illustSeriesId,
+          filter: parameters.filter ?? 'for_ios',
         })
       ),
       this.#http,
@@ -321,15 +324,15 @@ export class IllustResource {
    * Adds an illust bookmark.
    * POST /v2/illust/bookmark/add
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   bookmarkAdd(
-    params: IllustBookmarkAddParams
+    parameters: IllustBookmarkAddParameters
   ): ResultAsync<Record<string, never>, PixivError> {
-    const body = buildParams({
-      illustId: params.illustId,
-      restrict: params.restrict ?? 'public',
-      ...(params.tags ? { tags: params.tags } : {}),
+    const body = buildParameters({
+      illustId: parameters.illustId,
+      restrict: parameters.restrict ?? 'public',
+      ...(parameters.tags && { tags: parameters.tags }),
     })
     return this.#http.post<Record<string, never>>(
       '/v2/illust/bookmark/add',
@@ -341,12 +344,12 @@ export class IllustResource {
    * Removes an illust bookmark.
    * POST /v1/illust/bookmark/delete
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   bookmarkDelete(
-    params: IllustBookmarkDeleteParams
+    parameters: IllustBookmarkDeleteParameters
   ): ResultAsync<Record<string, never>, PixivError> {
-    const body = buildParams({ illustId: String(params.illustId) })
+    const body = buildParameters({ illustId: String(parameters.illustId) })
     return this.#http.post<Record<string, never>>(
       '/v1/illust/bookmark/delete',
       body.toString()

--- a/packages/core/src/resources/manga.ts
+++ b/packages/core/src/resources/manga.ts
@@ -2,13 +2,13 @@
  * MangaResource — methods for the manga API namespace.
  */
 import type { HttpClient } from '../http'
-import { buildParams } from '../params'
+import { buildParameters } from '../parameters'
 import { PaginatedResultAsync } from '../paginated'
 import { OSFilter } from '../options'
 import type { MangaRecommendedPage, PixivIllustItem } from '../types'
 
 /** Parameters for fetching recommended manga. */
-export interface MangaRecommendedParams {
+export interface MangaRecommendedParameters {
   /** OS filter to apply (default: `"for_ios"`). */
   filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Zero-based offset for pagination. */
@@ -27,19 +27,19 @@ export class MangaResource {
    * Fetches recommended manga.
    * GET /v1/manga/recommended
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   recommended(
-    params: MangaRecommendedParams = {}
+    parameters: MangaRecommendedParameters = {}
   ): PaginatedResultAsync<MangaRecommendedPage, PixivIllustItem> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<MangaRecommendedPage>(
         '/v1/manga/recommended',
-        buildParams({
-          filter: params.filter ?? 'for_ios',
+        buildParameters({
+          filter: parameters.filter ?? 'for_ios',
           includeRankingIllusts: true,
           includePrivacyPolicy: true,
-          offset: params.offset,
+          offset: parameters.offset,
         })
       ),
       this.#http,

--- a/packages/core/src/resources/novels.ts
+++ b/packages/core/src/resources/novels.ts
@@ -3,7 +3,7 @@
  */
 import type { HttpClient } from '../http'
 import type { PixivError } from '../errors'
-import { buildParams } from '../params'
+import { buildParameters } from '../parameters'
 import { PaginatedResultAsync } from '../paginated'
 import type { ResultAsync } from '../result'
 import {
@@ -25,25 +25,25 @@ import type {
 // === Request param types ===
 
 /** Parameters for fetching a single novel by ID. */
-export interface NovelDetailParams {
+export interface NovelDetailParameters {
   /** ID of the novel to fetch. */
   novelId: number
 }
 
 /** Parameters for fetching the WebView HTML of a novel. */
-export interface NovelTextParams {
+export interface NovelTextParameters {
   /** ID of the novel whose WebView HTML to fetch. */
   novelId: number
 }
 
 /** Parameters for fetching related novels. */
-export interface NovelRelatedParams {
+export interface NovelRelatedParameters {
   /** ID of the novel for which to fetch related works. */
   novelId: number
 }
 
 /** Parameters for searching novels. */
-export interface NovelSearchParams {
+export interface NovelSearchParameters {
   /** Search keyword. */
   word: string
   /** How to match the keyword against works (default: `"partial_match_for_tags"`). */
@@ -65,7 +65,7 @@ export interface NovelSearchParams {
 }
 
 /** Parameters for fetching the novel ranking. */
-export interface NovelRankingParams {
+export interface NovelRankingParameters {
   /** Ranking category (default: `"day"`). */
   mode?: (typeof NovelRankingMode)[keyof typeof NovelRankingMode]
   /** OS filter to apply (default: `"for_ios"`). */
@@ -77,7 +77,7 @@ export interface NovelRankingParams {
 }
 
 /** Parameters for fetching recommended novels. */
-export interface NovelRecommendedParams {
+export interface NovelRecommendedParameters {
   /** OS filter to apply (default: `"for_ios"`). */
   filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Zero-based offset for pagination. */
@@ -90,7 +90,7 @@ export interface NovelRecommendedParams {
 }
 
 /** Parameters for fetching a novel series. */
-export interface NovelSeriesParams {
+export interface NovelSeriesParameters {
   /** ID of the novel series to fetch. */
   seriesId: number
   /** Order of the last novel already seen; used for cursor-based pagination. */
@@ -98,7 +98,7 @@ export interface NovelSeriesParams {
 }
 
 /** Parameters for adding a novel bookmark. */
-export interface NovelBookmarkAddParams {
+export interface NovelBookmarkAddParameters {
   /** ID of the novel to bookmark. */
   novelId: number
   /** Bookmark visibility (default: `"public"`). */
@@ -108,7 +108,7 @@ export interface NovelBookmarkAddParams {
 }
 
 /** Parameters for removing a novel bookmark. */
-export interface NovelBookmarkDeleteParams {
+export interface NovelBookmarkDeleteParameters {
   /** ID of the novel to remove from bookmarks. */
   novelId: number
 }
@@ -125,7 +125,7 @@ export class NovelResource {
    * Fetches a single novel by ID.
    * GET /v2/novel/detail
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    *
    * @example
    * ```ts
@@ -138,11 +138,11 @@ export class NovelResource {
    * ```
    */
   detail(
-    params: NovelDetailParams
+    parameters: NovelDetailParameters
   ): ResultAsync<NovelDetailResponse, PixivError> {
     return this.#http.get<NovelDetailResponse>(
       '/v2/novel/detail',
-      buildParams({ novelId: params.novelId })
+      buildParameters({ novelId: parameters.novelId })
     )
   }
 
@@ -153,13 +153,13 @@ export class NovelResource {
    * Returns the raw HTML page that the pixiv app renders in a WebView.
    * To extract the plain text, parse the returned HTML (e.g. strip tags).
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
-  text(params: NovelTextParams): ResultAsync<string, PixivError> {
+  text(parameters: NovelTextParameters): ResultAsync<string, PixivError> {
     return this.#http.get<string>(
       '/webview/v2/novel',
       // The webview endpoint uses the query parameter 'id', not 'novel_id'
-      buildParams({ id: params.novelId })
+      buildParameters({ id: parameters.novelId })
     )
   }
 
@@ -167,15 +167,15 @@ export class NovelResource {
    * Fetches related novels for a given novel.
    * GET /v1/novel/related
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   related(
-    params: NovelRelatedParams
+    parameters: NovelRelatedParameters
   ): PaginatedResultAsync<NovelListPage, PixivNovelItem> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<NovelListPage>(
         '/v1/novel/related',
-        buildParams({ novelId: params.novelId })
+        buildParameters({ novelId: parameters.novelId })
       ),
       this.#http,
       (page) => page.novels
@@ -186,7 +186,7 @@ export class NovelResource {
    * Searches for novels.
    * GET /v1/search/novel
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    *
    * @example
    * ```ts
@@ -203,21 +203,21 @@ export class NovelResource {
    * ```
    */
   search(
-    params: NovelSearchParams
+    parameters: NovelSearchParameters
   ): PaginatedResultAsync<NovelListPage, PixivNovelItem> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<NovelListPage>(
         '/v1/search/novel',
-        buildParams({
-          word: params.word,
-          searchTarget: params.searchTarget ?? 'partial_match_for_tags',
-          sort: params.sort ?? 'date_desc',
-          filter: params.filter ?? 'for_ios',
-          duration: params.duration,
-          startDate: params.startDate,
-          endDate: params.endDate,
-          searchAiType: params.searchAiType,
-          offset: params.offset,
+        buildParameters({
+          word: parameters.word,
+          searchTarget: parameters.searchTarget ?? 'partial_match_for_tags',
+          sort: parameters.sort ?? 'date_desc',
+          filter: parameters.filter ?? 'for_ios',
+          duration: parameters.duration,
+          startDate: parameters.startDate,
+          endDate: parameters.endDate,
+          searchAiType: parameters.searchAiType,
+          offset: parameters.offset,
         })
       ),
       this.#http,
@@ -229,19 +229,19 @@ export class NovelResource {
    * Fetches the novel ranking.
    * GET /v1/novel/ranking
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   ranking(
-    params: NovelRankingParams = {}
+    parameters: NovelRankingParameters = {}
   ): PaginatedResultAsync<NovelListPage, PixivNovelItem> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<NovelListPage>(
         '/v1/novel/ranking',
-        buildParams({
-          mode: params.mode ?? 'day',
-          filter: params.filter ?? 'for_ios',
-          date: params.date,
-          offset: params.offset,
+        buildParameters({
+          mode: parameters.mode ?? 'day',
+          filter: parameters.filter ?? 'for_ios',
+          date: parameters.date,
+          offset: parameters.offset,
         })
       ),
       this.#http,
@@ -253,20 +253,20 @@ export class NovelResource {
    * Fetches recommended novels.
    * GET /v1/novel/recommended
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   recommended(
-    params: NovelRecommendedParams = {}
+    parameters: NovelRecommendedParameters = {}
   ): PaginatedResultAsync<NovelRecommendedPage, PixivNovelItem> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<NovelRecommendedPage>(
         '/v1/novel/recommended',
-        buildParams({
-          filter: params.filter ?? 'for_ios',
+        buildParameters({
+          filter: parameters.filter ?? 'for_ios',
           includeRankingNovels: true,
           includePrivacyPolicy: true,
-          offset: params.offset,
-          maxBookmarkIdForRecommend: params.maxBookmarkIdForRecommend,
+          offset: parameters.offset,
+          maxBookmarkIdForRecommend: parameters.maxBookmarkIdForRecommend,
         })
       ),
       this.#http,
@@ -278,15 +278,18 @@ export class NovelResource {
    * Fetches a novel series.
    * GET /v2/novel/series
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   series(
-    params: NovelSeriesParams
+    parameters: NovelSeriesParameters
   ): PaginatedResultAsync<NovelSeriesPage, PixivNovelItem> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<NovelSeriesPage>(
         '/v2/novel/series',
-        buildParams({ seriesId: params.seriesId, lastOrder: params.lastOrder })
+        buildParameters({
+          seriesId: parameters.seriesId,
+          lastOrder: parameters.lastOrder,
+        })
       ),
       this.#http,
       (page) => page.novels
@@ -297,15 +300,15 @@ export class NovelResource {
    * Adds a novel bookmark.
    * POST /v2/novel/bookmark/add
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   bookmarkAdd(
-    params: NovelBookmarkAddParams
+    parameters: NovelBookmarkAddParameters
   ): ResultAsync<Record<string, never>, PixivError> {
-    const body = buildParams({
-      novelId: params.novelId,
-      restrict: params.restrict ?? 'public',
-      ...(params.tags ? { tags: params.tags } : {}),
+    const body = buildParameters({
+      novelId: parameters.novelId,
+      restrict: parameters.restrict ?? 'public',
+      ...(parameters.tags && { tags: parameters.tags }),
     })
     return this.#http.post<Record<string, never>>(
       '/v2/novel/bookmark/add',
@@ -317,12 +320,12 @@ export class NovelResource {
    * Removes a novel bookmark.
    * POST /v1/novel/bookmark/delete
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   bookmarkDelete(
-    params: NovelBookmarkDeleteParams
+    parameters: NovelBookmarkDeleteParameters
   ): ResultAsync<Record<string, never>, PixivError> {
-    const body = buildParams({ novelId: String(params.novelId) })
+    const body = buildParameters({ novelId: String(parameters.novelId) })
     return this.#http.post<Record<string, never>>(
       '/v1/novel/bookmark/delete',
       body.toString()

--- a/packages/core/src/resources/ugoira.ts
+++ b/packages/core/src/resources/ugoira.ts
@@ -3,12 +3,12 @@
  */
 import type { HttpClient } from '../http'
 import type { PixivError } from '../errors'
-import { buildParams } from '../params'
+import { buildParameters } from '../parameters'
 import type { ResultAsync } from '../result'
 import type { UgoiraMetadataResponse } from '../types'
 
 /** Parameters for fetching ugoira metadata. */
-export interface UgoiraMetadataParams {
+export interface UgoiraMetadataParameters {
   /** ID of the ugoira illust whose metadata to fetch. */
   illustId: number
 }
@@ -25,14 +25,14 @@ export class UgoiraResource {
    * Fetches ugoira metadata (ZIP URL and per-frame timings).
    * GET /v1/ugoira/metadata
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   metadata(
-    params: UgoiraMetadataParams
+    parameters: UgoiraMetadataParameters
   ): ResultAsync<UgoiraMetadataResponse, PixivError> {
     return this.#http.get<UgoiraMetadataResponse>(
       '/v1/ugoira/metadata',
-      buildParams({ illustId: params.illustId })
+      buildParameters({ illustId: parameters.illustId })
     )
   }
 }

--- a/packages/core/src/resources/users.ts
+++ b/packages/core/src/resources/users.ts
@@ -3,7 +3,7 @@
  */
 import type { HttpClient } from '../http'
 import type { PixivError } from '../errors'
-import { buildParams } from '../params'
+import { buildParameters } from '../parameters'
 import { PaginatedResultAsync } from '../paginated'
 import type { ResultAsync } from '../result'
 import {
@@ -27,7 +27,7 @@ import type {
 // === Request param types ===
 
 /** Parameters for fetching a user's bookmarked illusts. */
-export interface UserBookmarksIllustParams {
+export interface UserBookmarksIllustParameters {
   /** ID of the user whose bookmarks to fetch. */
   userId: number
   /** Visibility of the bookmarks to return (default: `"public"`). */
@@ -43,7 +43,7 @@ export interface UserBookmarksIllustParams {
 }
 
 /** Parameters for fetching a user's bookmarked novels. */
-export interface UserBookmarksNovelParams {
+export interface UserBookmarksNovelParameters {
   /** ID of the user whose bookmarks to fetch. */
   userId: number
   /** Visibility of the bookmarks to return (default: `"public"`). */
@@ -59,7 +59,7 @@ export interface UserBookmarksNovelParams {
 }
 
 /** Parameters for fetching a user's detail. */
-export interface UserDetailParams {
+export interface UserDetailParameters {
   /** ID of the user to fetch. */
   userId: number
   /** OS filter to apply (default: `"for_ios"`). */
@@ -67,7 +67,7 @@ export interface UserDetailParams {
 }
 
 /** Parameters for fetching a user's illusts. */
-export interface UserIllustsParams {
+export interface UserIllustsParameters {
   /** ID of the user whose illusts to fetch. */
   userId: number
   /** Work type to filter by (omit to return both illusts and manga). */
@@ -79,7 +79,7 @@ export interface UserIllustsParams {
 }
 
 /** Parameters for fetching a user's novels. */
-export interface UserNovelsParams {
+export interface UserNovelsParameters {
   /** ID of the user whose novels to fetch. */
   userId: number
   /** OS filter to apply (default: `"for_ios"`). */
@@ -89,7 +89,7 @@ export interface UserNovelsParams {
 }
 
 /** Parameters for fetching a user's following list. */
-export interface UserFollowingParams {
+export interface UserFollowingParameters {
   /** ID of the user whose following list to fetch. */
   userId: number
   /** Visibility of the follows to return (default: `"public"`). */
@@ -99,7 +99,7 @@ export interface UserFollowingParams {
 }
 
 /** Parameters for following a user. */
-export interface UserFollowAddParams {
+export interface UserFollowAddParameters {
   /** ID of the user to follow. */
   userId: number
   /** Visibility of the follow (default: `"public"`). */
@@ -107,7 +107,7 @@ export interface UserFollowAddParams {
 }
 
 /** Parameters for unfollowing a user. */
-export interface UserFollowDeleteParams {
+export interface UserFollowDeleteParameters {
   /** ID of the user to unfollow. */
   userId: number
 }
@@ -124,7 +124,7 @@ export class UserBookmarksResource {
    * Fetches a user's bookmarked illusts.
    * GET /v1/user/bookmarks/illust
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    *
    * @example
    * ```ts
@@ -146,18 +146,18 @@ export class UserBookmarksResource {
    * ```
    */
   illusts(
-    params: UserBookmarksIllustParams
+    parameters: UserBookmarksIllustParameters
   ): PaginatedResultAsync<UserBookmarksIllustPage, PixivIllustItem> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<UserBookmarksIllustPage>(
         '/v1/user/bookmarks/illust',
-        buildParams({
-          userId: params.userId,
-          restrict: params.restrict ?? 'public',
-          filter: params.filter ?? 'for_ios',
-          tag: params.tag,
-          maxBookmarkId: params.maxBookmarkId,
-          offset: params.offset,
+        buildParameters({
+          userId: parameters.userId,
+          restrict: parameters.restrict ?? 'public',
+          filter: parameters.filter ?? 'for_ios',
+          tag: parameters.tag,
+          maxBookmarkId: parameters.maxBookmarkId,
+          offset: parameters.offset,
         })
       ),
       this.#http,
@@ -169,7 +169,7 @@ export class UserBookmarksResource {
    * Fetches a user's bookmarked novels.
    * GET /v1/user/bookmarks/novel
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    *
    * @example
    * ```ts
@@ -180,18 +180,18 @@ export class UserBookmarksResource {
    * ```
    */
   novels(
-    params: UserBookmarksNovelParams
+    parameters: UserBookmarksNovelParameters
   ): PaginatedResultAsync<UserBookmarksNovelPage, PixivNovelItem> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<UserBookmarksNovelPage>(
         '/v1/user/bookmarks/novel',
-        buildParams({
-          userId: params.userId,
-          restrict: params.restrict ?? 'public',
-          filter: params.filter ?? 'for_ios',
-          tag: params.tag,
-          maxBookmarkId: params.maxBookmarkId,
-          offset: params.offset,
+        buildParameters({
+          userId: parameters.userId,
+          restrict: parameters.restrict ?? 'public',
+          filter: parameters.filter ?? 'for_ios',
+          tag: parameters.tag,
+          maxBookmarkId: parameters.maxBookmarkId,
+          offset: parameters.offset,
         })
       ),
       this.#http,
@@ -216,14 +216,17 @@ export class UserResource {
    * Fetches detailed profile information for a user.
    * GET /v1/user/detail
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   detail(
-    params: UserDetailParams
+    parameters: UserDetailParameters
   ): ResultAsync<UserDetailResponse, PixivError> {
     return this.#http.get<UserDetailResponse>(
       '/v1/user/detail',
-      buildParams({ userId: params.userId, filter: params.filter ?? 'for_ios' })
+      buildParameters({
+        userId: parameters.userId,
+        filter: parameters.filter ?? 'for_ios',
+      })
     )
   }
 
@@ -231,19 +234,19 @@ export class UserResource {
    * Fetches illusts posted by a user.
    * GET /v1/user/illusts
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   illusts(
-    params: UserIllustsParams
+    parameters: UserIllustsParameters
   ): PaginatedResultAsync<UserIllustsPage, PixivIllustItem> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<UserIllustsPage>(
         '/v1/user/illusts',
-        buildParams({
-          userId: params.userId,
-          type: params.type,
-          filter: params.filter ?? 'for_ios',
-          offset: params.offset,
+        buildParameters({
+          userId: parameters.userId,
+          type: parameters.type,
+          filter: parameters.filter ?? 'for_ios',
+          offset: parameters.offset,
         })
       ),
       this.#http,
@@ -255,18 +258,18 @@ export class UserResource {
    * Fetches novels posted by a user.
    * GET /v1/user/novels
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   novels(
-    params: UserNovelsParams
+    parameters: UserNovelsParameters
   ): PaginatedResultAsync<UserNovelsPage, PixivNovelItem> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<UserNovelsPage>(
         '/v1/user/novels',
-        buildParams({
-          userId: params.userId,
-          filter: params.filter ?? 'for_ios',
-          offset: params.offset,
+        buildParameters({
+          userId: parameters.userId,
+          filter: parameters.filter ?? 'for_ios',
+          offset: parameters.offset,
         })
       ),
       this.#http,
@@ -278,18 +281,18 @@ export class UserResource {
    * Fetches the list of users that a user is following.
    * GET /v1/user/following
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   following(
-    params: UserFollowingParams
+    parameters: UserFollowingParameters
   ): PaginatedResultAsync<UserFollowingPage, PixivUserPreviewItem> {
     return PaginatedResultAsync.fromResultAsync(
       this.#http.get<UserFollowingPage>(
         '/v1/user/following',
-        buildParams({
-          userId: params.userId,
-          restrict: params.restrict ?? 'public',
-          offset: params.offset,
+        buildParameters({
+          userId: parameters.userId,
+          restrict: parameters.restrict ?? 'public',
+          offset: parameters.offset,
         })
       ),
       this.#http,
@@ -301,14 +304,14 @@ export class UserResource {
    * Follows a user.
    * POST /v1/user/follow/add
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   followAdd(
-    params: UserFollowAddParams
+    parameters: UserFollowAddParameters
   ): ResultAsync<Record<string, never>, PixivError> {
-    const body = buildParams({
-      userId: params.userId,
-      restrict: params.restrict ?? 'public',
+    const body = buildParameters({
+      userId: parameters.userId,
+      restrict: parameters.restrict ?? 'public',
     })
     return this.#http.post<Record<string, never>>(
       '/v1/user/follow/add',
@@ -320,12 +323,12 @@ export class UserResource {
    * Unfollows a user.
    * POST /v1/user/follow/delete
    *
-   * @param params - Request parameters
+   * @param parameters - Request parameters
    */
   followDelete(
-    params: UserFollowDeleteParams
+    parameters: UserFollowDeleteParameters
   ): ResultAsync<Record<string, never>, PixivError> {
-    const body = buildParams({ userId: String(params.userId) })
+    const body = buildParameters({ userId: String(parameters.userId) })
     return this.#http.post<Record<string, never>>(
       '/v1/user/follow/delete',
       body.toString()

--- a/packages/core/src/result.ts
+++ b/packages/core/src/result.ts
@@ -29,41 +29,41 @@ export interface OkResult<T> {
   /** The success value. */
   readonly value: T
   /** Returns an `OkResult` with `fn(value)`. */
-  map<U>(fn: (value: T) => U): OkResult<U>
+  map<U>(function_: (value: T) => U): OkResult<U>
   /** Returns `this` unchanged. */
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- F is part of the public API contract, symmetric with ErrResult.mapErr<F>
-  mapErr<F>(_fn: (error: never) => F): OkResult<T>
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- F is part of the public API contract, symmetric with ErrorResult.mapErr<F>
+  mapErr<F>(_function: (error: never) => F): OkResult<T>
   /** Calls `fn(value)` and returns its Result. */
-  andThen<U, F>(fn: (value: T) => Result<U, F>): Result<U, F>
+  andThen<U, F>(function_: (value: T) => Result<U, F>): Result<U, F>
   /** Calls `onOk` and returns its result. */
-  match<U>(onOk: (value: T) => U, _onErr: (error: never) => U): U
+  match<U>(onOk: (value: T) => U, _onError: (error: never) => U): U
   /** Returns `value`. */
   unwrapOr(_fallback: T): T
 }
 
 /** Failed result carrying `error`. */
-export interface ErrResult<E> {
-  /** Always `false` — use this to narrow the union to `ErrResult<E>`. */
+export interface ErrorResult<E> {
+  /** Always `false` — use this to narrow the union to `ErrorResult<E>`. */
   readonly isOk: false
-  /** Always `true` — use this to narrow the union to `ErrResult<E>`. */
+  /** Always `true` — use this to narrow the union to `ErrorResult<E>`. */
   readonly isErr: true
   /** The error value. */
   readonly error: E
   /** Returns `this` unchanged. */
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- U is part of the public API contract, symmetric with OkResult.map<U>
-  map<U>(_fn: (value: never) => U): ErrResult<E>
-  /** Returns an `ErrResult` with `fn(error)`. */
-  mapErr<F>(fn: (error: E) => F): ErrResult<F>
+  map<U>(_function: (value: never) => U): ErrorResult<E>
+  /** Returns an `ErrorResult` with `fn(error)`. */
+  mapErr<F>(function_: (error: E) => F): ErrorResult<F>
   /** Returns `this` unchanged. */
-  andThen<U, F>(_fn: (value: never) => Result<U, F>): ErrResult<E>
+  andThen<U, F>(_function: (value: never) => Result<U, F>): ErrorResult<E>
   /** Calls `onErr` and returns its result. */
-  match<U>(_onOk: (value: never) => U, onErr: (error: E) => U): U
+  match<U>(_onOk: (value: never) => U, onError: (error: E) => U): U
   /** Returns `fallback`. */
   unwrapOr<T>(fallback: T): T
 }
 
-/** A value that is either `OkResult<T>` or `ErrResult<E>`. */
-export type Result<T, E> = OkResult<T> | ErrResult<E>
+/** A value that is either `OkResult<T>` or `ErrorResult<E>`. */
+export type Result<T, E> = OkResult<T> | ErrorResult<E>
 
 class OkResultImpl<T> implements OkResult<T> {
   readonly isOk = true as const
@@ -71,21 +71,21 @@ class OkResultImpl<T> implements OkResult<T> {
 
   constructor(readonly value: T) {}
 
-  map<U>(fn: (value: T) => U): OkResult<U> {
-    return new OkResultImpl(fn(this.value))
+  map<U>(function_: (value: T) => U): OkResult<U> {
+    return new OkResultImpl(function_(this.value))
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters, @typescript-eslint/no-unused-vars -- F is part of the public API contract; _fn is intentionally unused (OkResult.mapErr is a no-op)
-  mapErr<F>(_fn: (error: never) => F): OkResult<T> {
+  mapErr<F>(_function: (error: never) => F): OkResult<T> {
     return this
   }
 
-  andThen<U, F>(fn: (value: T) => Result<U, F>): Result<U, F> {
-    return fn(this.value)
+  andThen<U, F>(function_: (value: T) => Result<U, F>): Result<U, F> {
+    return function_(this.value)
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- _onErr is intentionally unused: OkResult.match always calls onOk
-  match<U>(onOk: (value: T) => U, _onErr: (error: never) => U): U {
+  match<U>(onOk: (value: T) => U, _onError: (error: never) => U): U {
     return onOk(this.value)
   }
 
@@ -95,29 +95,29 @@ class OkResultImpl<T> implements OkResult<T> {
   }
 }
 
-class ErrResultImpl<E> implements ErrResult<E> {
+class ErrorResultImpl<E> implements ErrorResult<E> {
   readonly isOk = false as const
   readonly isErr = true as const
 
   // eslint-disable-next-line n/handle-callback-err -- 'error' is a stored value, not a Node.js callback error parameter
   constructor(readonly error: E) {}
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters, @typescript-eslint/no-unused-vars -- U is part of the public API contract; _fn is intentionally unused (ErrResult.map is a no-op)
-  map<U>(_fn: (value: never) => U): ErrResult<E> {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters, @typescript-eslint/no-unused-vars -- U is part of the public API contract; _fn is intentionally unused (ErrorResult.map is a no-op)
+  map<U>(_function: (value: never) => U): ErrorResult<E> {
     return this
   }
 
-  mapErr<F>(fn: (error: E) => F): ErrResult<F> {
-    return new ErrResultImpl(fn(this.error))
+  mapErr<F>(function_: (error: E) => F): ErrorResult<F> {
+    return new ErrorResultImpl(function_(this.error))
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- _fn is intentionally unused: ErrResult.andThen is a no-op (the success path does not apply)
-  andThen<U, F>(_fn: (value: never) => Result<U, F>): ErrResult<E> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- _fn is intentionally unused: ErrorResult.andThen is a no-op (the success path does not apply)
+  andThen<U, F>(_function: (value: never) => Result<U, F>): ErrorResult<E> {
     return this
   }
 
-  match<U>(_onOk: (value: never) => U, onErr: (error: E) => U): U {
-    return onErr(this.error)
+  match<U>(_onOk: (value: never) => U, onError: (error: E) => U): U {
+    return onError(this.error)
   }
 
   unwrapOr<T>(fallback: T): T {
@@ -139,9 +139,16 @@ export function ok<T>(value: T): OkResult<T> {
  *
  * @param error - The error value
  */
-export function err<E>(error: E): ErrResult<E> {
-  return new ErrResultImpl(error)
+export function err<E>(error: E): ErrorResult<E> {
+  return new ErrorResultImpl(error)
 }
+
+/**
+ * @deprecated Use {@link ErrorResult} instead. Kept as a type alias for
+ * backward compatibility with the pre-1.x `ErrResult` naming (renamed to
+ * `ErrorResult` to satisfy the `unicorn/name-replacements` lint rule).
+ */
+export type ErrResult<E> = ErrorResult<E>
 
 // ---------------------------------------------------------------------------
 // ResultAsync<T, E>
@@ -170,11 +177,9 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
   // eslint-disable-next-line unicorn/no-thenable -- ResultAsync intentionally implements PromiseLike to be directly awaitable
   then<TResult1 = Result<T, E>, TResult2 = never>(
     onfulfilled?:
-      | ((value: Result<T, E>) => TResult1 | PromiseLike<TResult1>)
-      | null,
+      ((value: Result<T, E>) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
   ): PromiseLike<TResult1 | TResult2> {
-
     return this._promise.then(onfulfilled, onrejected as any)
   }
 
@@ -191,10 +196,13 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
     onError: (reason: unknown) => E
   ): ResultAsync<T, E> {
     return new ResultAsync(
-      promise.then(
-        (v) => ok(v) as Result<T, E>,
-        (error: unknown) => err(onError(error)) as Result<T, E>
-      )
+      (async (): Promise<Result<T, E>> => {
+        try {
+          return ok(await promise)
+        } catch (error: unknown) {
+          return err(onError(error))
+        }
+      })()
     )
   }
 
@@ -210,49 +218,55 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
   /**
    * Transforms the success value.
    *
-   * If the inner result is `Err`, `fn` is not called.
+   * If the inner result is `Err`, `function_` is not called.
    *
-   * @param fn - Synchronous mapper
+   * @param function_ - Synchronous mapper
    */
-  map<U>(fn: (value: T) => U): ResultAsync<U, E> {
+  map<U>(function_: (value: T) => U): ResultAsync<U, E> {
     return new ResultAsync(
-      // eslint-disable-next-line unicorn/no-array-callback-reference -- r.map(fn) is safe here; fn is a user-supplied mapper, not a DOM/Array method reference
-      this._promise.then((r) => r.map(fn) as Result<U, E>)
+      (async (): Promise<Result<U, E>> => {
+        const r = await this._promise
+        return r.map((value) => function_(value))
+      })()
     )
   }
 
   /**
    * Transforms the error value.
    *
-   * If the inner result is `Ok`, `fn` is not called.
+   * If the inner result is `Ok`, `function_` is not called.
    *
-   * @param fn - Synchronous error mapper
+   * @param function_ - Synchronous error mapper
    */
-  mapErr<F>(fn: (error: E) => F): ResultAsync<T, F> {
+  mapErr<F>(function_: (error: E) => F): ResultAsync<T, F> {
     return new ResultAsync(
-      this._promise.then((r) => r.mapErr(fn) as Result<T, F>)
+      (async (): Promise<Result<T, F>> => {
+        const r = await this._promise
+        return r.mapErr((error) => function_(error))
+      })()
     )
   }
 
   /**
    * Chains another async operation that may fail.
    *
-   * If the inner result is `Err`, `fn` is not called.
+   * If the inner result is `Err`, `function_` is not called.
    *
-   * @param fn - Async mapper that returns a `ResultAsync<U, F>`
+   * @param function_ - Async mapper that returns a `ResultAsync<U, F>`
    */
   andThen<U, F>(
-    fn: (value: T) => ResultAsync<U, F> | Result<U, F>
+    function_: (value: T) => ResultAsync<U, F> | Result<U, F>
   ): ResultAsync<U, E | F> {
     return new ResultAsync(
-      this._promise.then(async (r): Promise<Result<U, E | F>> => {
+      (async (): Promise<Result<U, E | F>> => {
+        const r = await this._promise
         if (r.isErr) return r
-        const next = fn(r.value)
+        const next = function_(r.value)
         if (next instanceof ResultAsync) {
           return next._promise
         }
         return next
-      })
+      })()
     )
   }
 
@@ -260,16 +274,16 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
    * Pattern-matches on success / failure.
    *
    * @param onOk - Called with the success value
-   * @param onErr - Called with the error value
+   * @param onError - Called with the error value
    * @returns A `Promise<U>`
    */
   async match<U>(
     onOk: (value: T) => U | Promise<U>,
-    onErr: (error: E) => U | Promise<U>
+    onError: (error: E) => U | Promise<U>
   ): Promise<U> {
     const r = await this._promise
     if (r.isOk) return onOk(r.value)
-    return onErr(r.error)
+    return onError(r.error)
   }
 
   /**

--- a/packages/core/src/schemas/error.ts
+++ b/packages/core/src/schemas/error.ts
@@ -21,12 +21,14 @@ import { z } from 'zod'
  * }
  * ```
  */
+const UserMessageDetailsSchema = z.record(z.string(), z.unknown())
+
 export const PixivApiErrorBodySchema = z.object({
   error: z.object({
     userMessage: z.string(),
     message: z.string(),
     reason: z.string(),
-    userMessageDetails: z.record(z.string(), z.unknown()).optional(),
+    userMessageDetails: UserMessageDetailsSchema.optional(),
   }),
 })
 

--- a/packages/core/src/schemas/illust.ts
+++ b/packages/core/src/schemas/illust.ts
@@ -17,6 +17,9 @@ export const MetaSinglePageSchema = z.object({
   originalImageUrl: z.string().optional(),
 })
 
+/** Placeholder for multi-page works, where `metaSinglePage` is `{}`. */
+const EmptyMetaSinglePageSchema = z.record(z.string(), z.never())
+
 /** Multi-page illust detail (imageUrls for each page). */
 export const MetaPagesSchema = z.object({
   imageUrls: ImageUrlsSchema.extend({
@@ -55,7 +58,7 @@ export const PixivIllustItemSchema = z.object({
    * For single-page works this is `{ originalImageUrl: string }`.
    * For multi-page works this is an empty object `{}`.
    */
-  metaSinglePage: z.union([MetaSinglePageSchema, z.record(z.string(), z.never())]),
+  metaSinglePage: z.union([MetaSinglePageSchema, EmptyMetaSinglePageSchema]),
   metaPages: z.array(MetaPagesSchema),
   totalView: z.number(),
   totalBookmarks: z.number(),

--- a/packages/core/src/schemas/novel.ts
+++ b/packages/core/src/schemas/novel.ts
@@ -5,7 +5,15 @@
  */
 
 import { z } from 'zod'
-import { ImageUrlsSchema, PixivUserSchema, SeriesSchema, TagSchema } from './common'
+import {
+  ImageUrlsSchema,
+  PixivUserSchema,
+  SeriesSchema,
+  TagSchema,
+} from './common'
+
+/** Placeholder for novels with no series, where `series` is `{}`. */
+const EmptySeriesSchema = z.record(z.string(), z.never())
 
 /** A pixiv novel work item as returned by the API. */
 export const PixivNovelItemSchema = z.object({
@@ -35,7 +43,7 @@ export const PixivNovelItemSchema = z.object({
    *
    * Contains `{}` (empty object) if the novel does not belong to a series.
    */
-  series: z.union([SeriesSchema, z.record(z.string(), z.never())]),
+  series: z.union([SeriesSchema, EmptySeriesSchema]),
   isBookmarked: z.boolean(),
   totalBookmarks: z.number(),
   totalView: z.number(),

--- a/packages/core/tests/client.test.ts
+++ b/packages/core/tests/client.test.ts
@@ -145,26 +145,21 @@ describe('illusts.search().pages() — multi-page', () => {
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
         HttpResponse.json(AUTH_RESPONSE)
       ),
-      http.get(
-        'https://app-api.pixiv.net/v1/search/illust',
-        ({ request }) => {
-          const offset = new URL(request.url).searchParams.get('offset')
-          if (offset === '30') {
-            return HttpResponse.json({ illusts: [ILLUST2], next_url: null })
-          }
-          return HttpResponse.json({
-            illusts: [ILLUST],
-            next_url:
-              'https://app-api.pixiv.net/v1/search/illust?offset=30',
-          })
+      http.get('https://app-api.pixiv.net/v1/search/illust', ({ request }) => {
+        const offset = new URL(request.url).searchParams.get('offset')
+        if (offset === '30') {
+          return HttpResponse.json({ illusts: [ILLUST2], next_url: null })
         }
-      )
+        return HttpResponse.json({
+          illusts: [ILLUST],
+          next_url: 'https://app-api.pixiv.net/v1/search/illust?offset=30',
+        })
+      })
     )
     const client = await PixivClient.of('test-refresh-token')
     const pages: number[] = []
-    for await (const page of client.illusts
-      .search({ word: 'cat' })
-      .pages()) {
+    const pageIterable = client.illusts.search({ word: 'cat' }).pages()
+    for await (const page of pageIterable) {
       pages.push(page.illusts.length)
     }
     expect(pages).toHaveLength(2)
@@ -182,29 +177,24 @@ describe('illusts.search().items() — multi-page', () => {
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
         HttpResponse.json(AUTH_RESPONSE)
       ),
-      http.get(
-        'https://app-api.pixiv.net/v1/search/illust',
-        ({ request }) => {
-          const offset = new URL(request.url).searchParams.get('offset')
-          if (offset === '30') {
-            return HttpResponse.json({
-              illusts: [ILLUST3, ILLUST4],
-              next_url: null,
-            })
-          }
+      http.get('https://app-api.pixiv.net/v1/search/illust', ({ request }) => {
+        const offset = new URL(request.url).searchParams.get('offset')
+        if (offset === '30') {
           return HttpResponse.json({
-            illusts: [ILLUST, ILLUST2],
-            next_url:
-              'https://app-api.pixiv.net/v1/search/illust?offset=30',
+            illusts: [ILLUST3, ILLUST4],
+            next_url: null,
           })
         }
-      )
+        return HttpResponse.json({
+          illusts: [ILLUST, ILLUST2],
+          next_url: 'https://app-api.pixiv.net/v1/search/illust?offset=30',
+        })
+      })
     )
     const client = await PixivClient.of('test-refresh-token')
     const ids: number[] = []
-    for await (const illust of client.illusts
-      .search({ word: 'cat' })
-      .items()) {
+    const itemIterable = client.illusts.search({ word: 'cat' }).items()
+    for await (const illust of itemIterable) {
       ids.push(illust.id)
     }
     expect(ids).toHaveLength(4)
@@ -219,14 +209,10 @@ describe('illusts.ranking()', () => {
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
         HttpResponse.json(AUTH_RESPONSE)
       ),
-      http.get(
-        'https://app-api.pixiv.net/v1/illust/ranking',
-        ({ request }) => {
-          capturedMode =
-            new URL(request.url).searchParams.get('mode') ?? ''
-          return HttpResponse.json({ illusts: [ILLUST], next_url: null })
-        }
-      )
+      http.get('https://app-api.pixiv.net/v1/illust/ranking', ({ request }) => {
+        capturedMode = new URL(request.url).searchParams.get('mode') ?? ''
+        return HttpResponse.json({ illusts: [ILLUST], next_url: null })
+      })
     )
     const client = await PixivClient.of('test-refresh-token')
     const result = await client.illusts.ranking({ mode: 'week' })
@@ -266,8 +252,8 @@ describe('illusts.recommended() — default params', () => {
     expect(result.isOk).toBe(true)
     expect(capturedUrl).toBeDefined()
     if (capturedUrl === undefined) return
-    const params = new URL(capturedUrl).searchParams
-    expect(params.get('include_ranking_label')).toBe('true')
+    const parameters = new URL(capturedUrl).searchParams
+    expect(parameters.get('include_ranking_label')).toBe('true')
   })
 })
 
@@ -291,8 +277,8 @@ describe('illusts.recommended() — contentType param', () => {
     expect(result.isOk).toBe(true)
     expect(capturedUrl).toBeDefined()
     if (capturedUrl === undefined) return
-    const params = new URL(capturedUrl).searchParams
-    expect(params.get('content_type')).toBe('manga')
+    const parameters = new URL(capturedUrl).searchParams
+    expect(parameters.get('content_type')).toBe('manga')
   })
 
   it('omits content_type when contentType is not specified', async () => {
@@ -314,8 +300,8 @@ describe('illusts.recommended() — contentType param', () => {
     expect(result.isOk).toBe(true)
     expect(capturedUrl).toBeDefined()
     if (capturedUrl === undefined) return
-    const params = new URL(capturedUrl).searchParams
-    expect(params.has('content_type')).toBe(false)
+    const parameters = new URL(capturedUrl).searchParams
+    expect(parameters.has('content_type')).toBe(false)
   })
 })
 
@@ -335,12 +321,14 @@ describe('illusts.recommended() — includeRankingLabel param', () => {
       )
     )
     const client = await PixivClient.of('test-refresh-token')
-    const result = await client.illusts.recommended({ includeRankingLabel: false })
+    const result = await client.illusts.recommended({
+      includeRankingLabel: false,
+    })
     expect(result.isOk).toBe(true)
     expect(capturedUrl).toBeDefined()
     if (capturedUrl === undefined) return
-    const params = new URL(capturedUrl).searchParams
-    expect(params.get('include_ranking_label')).toBe('false')
+    const parameters = new URL(capturedUrl).searchParams
+    expect(parameters.get('include_ranking_label')).toBe('false')
   })
 })
 
@@ -364,8 +352,8 @@ describe('illusts.recommended() — viewed param', () => {
     expect(result.isOk).toBe(true)
     expect(capturedUrl).toBeDefined()
     if (capturedUrl === undefined) return
-    const params = new URL(capturedUrl).searchParams
-    expect(params.getAll('viewed[]')).toEqual(['101', '202'])
+    const parameters = new URL(capturedUrl).searchParams
+    expect(parameters.getAll('viewed[]')).toEqual(['101', '202'])
   })
 
   it('omits viewed[] when viewed is not specified', async () => {
@@ -387,8 +375,8 @@ describe('illusts.recommended() — viewed param', () => {
     expect(result.isOk).toBe(true)
     expect(capturedUrl).toBeDefined()
     if (capturedUrl === undefined) return
-    const params = new URL(capturedUrl).searchParams
-    expect(params.has('viewed[]')).toBe(false)
+    const parameters = new URL(capturedUrl).searchParams
+    expect(parameters.has('viewed[]')).toBe(false)
   })
 })
 
@@ -403,13 +391,11 @@ describe('illusts.recommended() — meta_single_page regression (PIXIVTS-39)', (
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
         HttpResponse.json(AUTH_RESPONSE)
       ),
-      http.get(
-        'https://app-api.pixiv.net/v1/illust/recommended',
-        () =>
-          HttpResponse.json({
-            ...RECOMMENDED_RESPONSE,
-            illusts: [MANGA_ILLUST],
-          })
+      http.get('https://app-api.pixiv.net/v1/illust/recommended', () =>
+        HttpResponse.json({
+          ...RECOMMENDED_RESPONSE,
+          illusts: [MANGA_ILLUST],
+        })
       )
     )
     const client = await PixivClient.of('test-refresh-token')
@@ -429,9 +415,8 @@ describe('illusts.bookmarkAdd()', () => {
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
         HttpResponse.json(AUTH_RESPONSE)
       ),
-      http.post(
-        'https://app-api.pixiv.net/v2/illust/bookmark/add',
-        () => HttpResponse.json({})
+      http.post('https://app-api.pixiv.net/v2/illust/bookmark/add', () =>
+        HttpResponse.json({})
       )
     )
     const client = await PixivClient.of('test-refresh-token')
@@ -629,8 +614,8 @@ describe('users.bookmarks.novels()', () => {
     await client.users.bookmarks.novels({ userId: 42, maxBookmarkId: 9999 })
     expect(capturedUrl).toBeDefined()
     if (capturedUrl === undefined) return
-    const params = new URL(capturedUrl).searchParams
-    expect(params.get('max_bookmark_id')).toBe('9999')
+    const parameters = new URL(capturedUrl).searchParams
+    expect(parameters.get('max_bookmark_id')).toBe('9999')
   })
 })
 
@@ -669,10 +654,12 @@ describe('images.fetch()', () => {
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
         HttpResponse.json(AUTH_RESPONSE)
       ),
-      http.get(imageUrl, () =>
-        new HttpResponse(new Uint8Array([0xff, 0xd8]).buffer, {
-          headers: { 'Content-Type': 'image/jpeg' },
-        })
+      http.get(
+        imageUrl,
+        () =>
+          new HttpResponse(new Uint8Array([0xff, 0xd8]).buffer, {
+            headers: { 'Content-Type': 'image/jpeg' },
+          })
       )
     )
     const client = await PixivClient.of('test-refresh-token')

--- a/packages/core/tests/e2e/pixiv.e2e.test.ts
+++ b/packages/core/tests/e2e/pixiv.e2e.test.ts
@@ -32,7 +32,7 @@ function loadToken(): string | undefined {
 }
 
 const REFRESH_TOKEN = loadToken()
-const SKIP = !REFRESH_TOKEN
+const IS_SKIP = !REFRESH_TOKEN
 
 // ---------------------------------------------------------------------------
 // Test constants (stable public content)
@@ -60,7 +60,7 @@ const STAFF_USER_ID = 11
 // Suite
 // ---------------------------------------------------------------------------
 
-describe.skipIf(SKIP)('PixivClient e2e', () => {
+describe.skipIf(IS_SKIP)('PixivClient e2e', () => {
   let client: PixivClient
 
   beforeAll(async () => {
@@ -430,9 +430,8 @@ describe.skipIf(SKIP)('PixivClient e2e', () => {
   it('PaginatedResultAsync.pages() — iterates at least one page', async () => {
     let pageCount = 0
     let totalIllusts = 0
-    for await (const page of client.illusts
-      .search({ word: 'ホロライブ' })
-      .pages()) {
+    const pageIterable = client.illusts.search({ word: 'ホロライブ' }).pages()
+    for await (const page of pageIterable) {
       pageCount++
       totalIllusts += page.illusts.length
       if (pageCount >= 2) break
@@ -443,9 +442,8 @@ describe.skipIf(SKIP)('PixivClient e2e', () => {
 
   it('PaginatedResultAsync.items() — yields individual items', async () => {
     const illusts: unknown[] = []
-    for await (const illust of client.illusts
-      .search({ word: 'ホロライブ' })
-      .items()) {
+    const itemIterable = client.illusts.search({ word: 'ホロライブ' }).items()
+    for await (const illust of itemIterable) {
       illusts.push(illust)
       if (illusts.length >= 60) break // stop after ~2 pages
     }

--- a/packages/core/tests/http.test.ts
+++ b/packages/core/tests/http.test.ts
@@ -14,9 +14,12 @@ function makeAuth(accessToken = 'test-token'): AuthManager {
 
 function makeClient(
   auth: AuthManager = makeAuth(),
-  opts?: ConstructorParameters<typeof HttpClient>[1]
+  options?: ConstructorParameters<typeof HttpClient>[1]
 ): HttpClient {
-  return new HttpClient(auth, { retry: { maxRetries: 2, waitMs: 10 }, ...opts })
+  return new HttpClient(auth, {
+    retry: { maxRetries: 2, waitMs: 10 },
+    ...options,
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -68,8 +71,8 @@ describe('HttpClient.get()', () => {
         return HttpResponse.json({ illusts: [] })
       })
     )
-    const params = new URLSearchParams({ word: 'cat', filter: 'for_ios' })
-    await makeClient().get('/v1/search/illust', params)
+    const parameters = new URLSearchParams({ word: 'cat', filter: 'for_ios' })
+    await makeClient().get('/v1/search/illust', parameters)
     expect(captured).toContain('word=cat')
     expect(captured).toContain('filter=for_ios')
   })
@@ -130,14 +133,18 @@ describe('429 retry', () => {
 
   it('returns Err(rate_limit) after exhausting retries', async () => {
     server.use(
-      http.get('https://app-api.pixiv.net/v1/always-429', () =>
-        new HttpResponse(null, {
-          status: 429,
-          headers: { 'Retry-After': '0' },
-        })
+      http.get(
+        'https://app-api.pixiv.net/v1/always-429',
+        () =>
+          new HttpResponse(null, {
+            status: 429,
+            headers: { 'Retry-After': '0' },
+          })
       )
     )
-    const client = makeClient(makeAuth(), { retry: { maxRetries: 1, waitMs: 0 } })
+    const client = makeClient(makeAuth(), {
+      retry: { maxRetries: 1, waitMs: 0 },
+    })
     const r = await client.get('/v1/always-429')
     expect(r.isErr).toBe(true)
     if (r.isErr) expect(r.error.type).toBe('rate_limit')
@@ -171,7 +178,7 @@ describe('429 retry', () => {
 describe('401 auth refresh', () => {
   it('refreshes the token and retries on 401', async () => {
     let calls = 0
-    let sawNewToken = false
+    let isSawNewToken = false
 
     // Token refresh endpoint
     server.use(
@@ -187,7 +194,7 @@ describe('401 auth refresh', () => {
       http.get('https://app-api.pixiv.net/v1/auth-test', ({ request }) => {
         calls++
         if (request.headers.get('authorization') === 'Bearer refreshed-token') {
-          sawNewToken = true
+          isSawNewToken = true
           return HttpResponse.json({ ok: true })
         }
         return new HttpResponse(null, { status: 401 })
@@ -197,17 +204,19 @@ describe('401 auth refresh', () => {
     const auth = makeAuth('old-token')
     const r = await makeClient(auth).get('/v1/auth-test')
     expect(r.isOk).toBe(true)
-    expect(sawNewToken).toBe(true)
+    expect(isSawNewToken).toBe(true)
     expect(calls).toBe(2)
   })
 
   it('returns Err(auth_failed) when refresh itself fails', async () => {
     server.use(
-      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
-        new HttpResponse(null, { status: 400 })
+      http.post(
+        'https://oauth.secure.pixiv.net/auth/token',
+        () => new HttpResponse(null, { status: 400 })
       ),
-      http.get('https://app-api.pixiv.net/v1/auth-fail', () =>
-        new HttpResponse(null, { status: 401 })
+      http.get(
+        'https://app-api.pixiv.net/v1/auth-fail',
+        () => new HttpResponse(null, { status: 401 })
       )
     )
     const r = await makeClient().get('/v1/auth-fail')

--- a/packages/core/tests/paginated.test.ts
+++ b/packages/core/tests/paginated.test.ts
@@ -26,7 +26,11 @@ interface ItemPage extends PagedResponse {
 // ---------------------------------------------------------------------------
 
 function makeAuth(): AuthManager {
-  return new AuthManager({ userId: '1', accessToken: 'token', refreshToken: 'rt' })
+  return new AuthManager({
+    userId: '1',
+    accessToken: 'token',
+    refreshToken: 'rt',
+  })
 }
 
 function makeHttp(): HttpClient {
@@ -83,10 +87,7 @@ describe('PaginatedResultAsync — single page', () => {
       (page) => page.items
     )
 
-    const collected: ItemPage[] = []
-    for await (const page of paginated.pages()) {
-      collected.push(page)
-    }
+    const collected: ItemPage[] = await Array.fromAsync(paginated.pages())
     expect(collected).toHaveLength(1)
     expect(collected[0].items[0].id).toBe(1)
   })
@@ -111,12 +112,9 @@ describe('PaginatedResultAsync — single page', () => {
       (page) => page.items
     )
 
-    const collected: Item[] = []
-    for await (const item of paginated.items()) {
-      collected.push(item)
-    }
+    const collected: Item[] = await Array.fromAsync(paginated.items())
     expect(collected).toHaveLength(2)
-    expect(collected.map((i) => i.id)).toEqual([1, 2])
+    expect(collected.map((index) => index.id)).toEqual([1, 2])
   })
 })
 
@@ -161,7 +159,7 @@ describe('PaginatedResultAsync — multiple pages', () => {
 
     const ids: number[] = []
     for await (const page of paginated.pages()) {
-      ids.push(...page.items.map((i) => i.id))
+      ids.push(...page.items.map((index) => index.id))
     }
     expect(ids).toEqual([1, 2, 3])
   })
@@ -232,7 +230,7 @@ describe('PaginatedResultAsync — multiple pages', () => {
       if (collected.length === 2) break // stop before reaching next_url
     }
     expect(collected).toHaveLength(2)
-    expect(collected.map((i) => i.id)).toEqual([1, 2])
+    expect(collected.map((index) => index.id)).toEqual([1, 2])
   })
 
   it('pages() correctly counts page fetches', async () => {
@@ -262,10 +260,7 @@ describe('PaginatedResultAsync — multiple pages', () => {
       (page) => page.items
     )
 
-    const pages: ItemPage[] = []
-    for await (const page of paginated.pages()) {
-      pages.push(page)
-    }
+    const pages: ItemPage[] = await Array.fromAsync(paginated.pages())
 
     expect(pages).toHaveLength(2)
     expect(fetchCount).toBe(2)

--- a/packages/core/tests/parameters.test.ts
+++ b/packages/core/tests/parameters.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import {
-  buildParams,
-  buildSearchParams,
+  buildParameters,
+  buildSearchParameters,
   camelToSnake,
   camelizeKeys,
   parseNextUrl,
   snakeToCamel,
   toSnakeKeys,
-} from '../src/params'
+} from '../src/parameters'
 
 describe('camelToSnake()', () => {
   it('converts a single uppercase letter', () => {
@@ -36,8 +36,8 @@ describe('toSnakeKeys()', () => {
   })
 
   it('preserves values unchanged', () => {
-    const obj = { maxBookmarkId: undefined, tag: 'test' }
-    const result = toSnakeKeys(obj)
+    const object = { maxBookmarkId: undefined, tag: 'test' }
+    const result = toSnakeKeys(object)
     expect(result.max_bookmark_id).toBeUndefined()
     expect(result.tag).toBe('test')
   })
@@ -45,46 +45,46 @@ describe('toSnakeKeys()', () => {
 
 describe('buildSearchParams()', () => {
   it('serialises strings and numbers', () => {
-    const usp = buildSearchParams({ word: 'hello', offset: 30 })
+    const usp = buildSearchParameters({ word: 'hello', offset: 30 })
     expect(usp.get('word')).toBe('hello')
     expect(usp.get('offset')).toBe('30')
   })
 
   it('skips null and undefined', () => {
-    const usp = buildSearchParams({ a: null, b: undefined, c: 'x' })
+    const usp = buildSearchParameters({ a: null, b: undefined, c: 'x' })
     expect(usp.has('a')).toBe(false)
     expect(usp.has('b')).toBe(false)
     expect(usp.get('c')).toBe('x')
   })
 
   it('serialises booleans', () => {
-    const usp = buildSearchParams({ flag: true, other: false })
+    const usp = buildSearchParameters({ flag: true, other: false })
     expect(usp.get('flag')).toBe('true')
     expect(usp.get('other')).toBe('false')
   })
 
   it('appends array values with bracket suffix (Rails/pixiv convention)', () => {
-    const usp = buildSearchParams({ ids: [1, 2, 3] })
+    const usp = buildSearchParameters({ ids: [1, 2, 3] })
     // pixiv API expects key[]=value1&key[]=value2, not key=value1&key=value2
     expect(usp.getAll('ids[]')).toEqual(['1', '2', '3'])
     expect(usp.has('ids')).toBe(false)
   })
 
   it('appends string arrays with bracket suffix', () => {
-    const usp = buildSearchParams({ tags: ['a', 'b'] })
+    const usp = buildSearchParameters({ tags: ['a', 'b'] })
     expect(usp.getAll('tags[]')).toEqual(['a', 'b'])
   })
 })
 
 describe('buildParams()', () => {
   it('converts keys to snake_case and builds URLSearchParams', () => {
-    const usp = buildParams({ illustId: 12_345, filter: 'for_ios' })
+    const usp = buildParameters({ illustId: 12_345, filter: 'for_ios' })
     expect(usp.get('illust_id')).toBe('12345')
     expect(usp.get('filter')).toBe('for_ios')
   })
 
   it('converts camelCase array keys to snake_case with bracket suffix', () => {
-    const usp = buildParams({ seedIllustIds: [1, 2, 3] })
+    const usp = buildParameters({ seedIllustIds: [1, 2, 3] })
     // camelCase → snake_case: seedIllustIds → seed_illust_ids
     // array → bracket suffix: seed_illust_ids → seed_illust_ids[]
     expect(usp.getAll('seed_illust_ids[]')).toEqual(['1', '2', '3'])
@@ -93,7 +93,7 @@ describe('buildParams()', () => {
   })
 
   it('converts camelCase string array keys (tags) to snake_case with bracket suffix', () => {
-    const usp = buildParams({ tags: ['foo', 'bar'] })
+    const usp = buildParameters({ tags: ['foo', 'bar'] })
     expect(usp.getAll('tags[]')).toEqual(['foo', 'bar'])
     expect(usp.has('tags')).toBe(false)
   })

--- a/packages/core/tests/result.test.ts
+++ b/packages/core/tests/result.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { err, ok, Result, ResultAsync } from '../src/result'
+import { err as error, ok, Result, ResultAsync } from '../src/result'
 import {
   apiError,
   authFailedError,
@@ -40,7 +40,7 @@ describe('ok()', () => {
   })
 
   it('andThen chains to Err', () => {
-    const r = ok(5).andThen<number, string>(() => err('oops'))
+    const r = ok(5).andThen<number, string>(() => error('oops'))
     expect(r.isErr).toBe(true)
     if (!r.isErr) return
     expect(r.error).toBe('oops')
@@ -61,40 +61,40 @@ describe('ok()', () => {
 
 describe('err()', () => {
   it('creates an ErrResult', () => {
-    const r = err('bad')
+    const r = error('bad')
     expect(r.isOk).toBe(false)
     expect(r.isErr).toBe(true)
     expect(r.error).toBe('bad')
   })
 
   it('map is a no-op', () => {
-    const r = err<string>('e').map(() => 42)
+    const r = error<string>('e').map(() => 42)
     expect(r.isErr).toBe(true)
     expect(r.error).toBe('e')
   })
 
   it('mapErr transforms the error', () => {
-    const r = err('e').mapErr((e) => e.toUpperCase())
+    const r = error('e').mapErr((error_) => error_.toUpperCase())
     expect(r.isErr).toBe(true)
     expect(r.error).toBe('E')
   })
 
   it('andThen is a no-op', () => {
-    const r = err<string>('e').andThen<number, string>(() => ok(1))
+    const r = error<string>('e').andThen<number, string>(() => ok(1))
     expect(r.isErr).toBe(true)
     expect(r.error).toBe('e')
   })
 
   it('match calls onErr', () => {
-    const out = err('boom').match(
+    const out = error('boom').match(
       () => 'ok',
-      (e) => `err:${e}`
+      (error_) => `err:${error_}`
     )
     expect(out).toBe('err:boom')
   })
 
   it('unwrapOr returns the fallback', () => {
-    expect(err('e').unwrapOr(42)).toBe(42)
+    expect(error('e').unwrapOr(42)).toBe(42)
   })
 })
 
@@ -113,7 +113,8 @@ describe('ResultAsync.fromPromise()', () => {
   it('wraps a rejected promise into Err', async () => {
     const r = await ResultAsync.fromPromise(
       Promise.reject(new Error('oops')),
-      (e: unknown) => (e instanceof Error ? e.message : String(e))
+      (error_: unknown) =>
+        error_ instanceof Error ? error_.message : String(error_)
     )
     expect(r.isErr).toBe(true)
     if (!r.isErr) return
@@ -130,7 +131,7 @@ describe('ResultAsync.fromResult()', () => {
   })
 
   it('wraps an Err result', async () => {
-    const r = await ResultAsync.fromResult(err('e'))
+    const r = await ResultAsync.fromResult(error('e'))
     expect(r.isErr).toBe(true)
     if (!r.isErr) return
     expect(r.error).toBe('e')
@@ -146,20 +147,20 @@ describe('ResultAsync.map()', () => {
   })
 
   it('does not call fn on Err', async () => {
-    let called = false
-    const r = await ResultAsync.fromResult(err('e')).map(() => {
-      called = true
+    let isCalled = false
+    const r = await ResultAsync.fromResult(error('e')).map(() => {
+      isCalled = true
       return 0
     })
-    expect(called).toBe(false)
+    expect(isCalled).toBe(false)
     expect(r.isErr).toBe(true)
   })
 })
 
 describe('ResultAsync.mapErr()', () => {
   it('transforms the error', async () => {
-    const r = await ResultAsync.fromResult(err('x')).mapErr((e) =>
-      e.toUpperCase()
+    const r = await ResultAsync.fromResult(error('x')).mapErr((error_) =>
+      error_.toUpperCase()
     )
     expect(r.isErr).toBe(true)
     if (!r.isErr) return
@@ -167,12 +168,12 @@ describe('ResultAsync.mapErr()', () => {
   })
 
   it('does not call fn on Ok', async () => {
-    let called = false
+    let isCalled = false
     const r = await ResultAsync.fromResult(ok(1)).mapErr(() => {
-      called = true
+      isCalled = true
       return 'e'
     })
-    expect(called).toBe(false)
+    expect(isCalled).toBe(false)
     expect(r.isOk).toBe(true)
   })
 })
@@ -188,12 +189,12 @@ describe('ResultAsync.andThen()', () => {
   })
 
   it('short-circuits on Err', async () => {
-    let called = false
-    const r = await ResultAsync.fromResult(err<string>('e')).andThen(() => {
-      called = true
+    let isCalled = false
+    const r = await ResultAsync.fromResult(error<string>('e')).andThen(() => {
+      isCalled = true
       return ResultAsync.fromResult(ok(1))
     })
-    expect(called).toBe(false)
+    expect(isCalled).toBe(false)
     expect(r.isErr).toBe(true)
     if (!r.isErr) return
     expect(r.error).toBe('e')
@@ -201,7 +202,7 @@ describe('ResultAsync.andThen()', () => {
 
   it('propagates Err from the chained fn', async () => {
     const r = await ResultAsync.fromResult(ok(1)).andThen<number, string>(() =>
-      ResultAsync.fromResult(err('chain-err'))
+      ResultAsync.fromResult(error('chain-err'))
     )
     expect(r.isErr).toBe(true)
     if (!r.isErr) return
@@ -219,9 +220,9 @@ describe('ResultAsync.match()', () => {
   })
 
   it('calls onErr for a failed result', async () => {
-    const out = await ResultAsync.fromResult(err('boom')).match(
+    const out = await ResultAsync.fromResult(error('boom')).match(
       () => 'ok',
-      (e) => `err:${e}`
+      (error_) => `err:${error_}`
     )
     expect(out).toBe('err:boom')
   })
@@ -233,7 +234,7 @@ describe('ResultAsync.unwrapOr()', () => {
   })
 
   it('returns the fallback on Err', async () => {
-    expect(await ResultAsync.fromResult(err('e')).unwrapOr(99)).toBe(99)
+    expect(await ResultAsync.fromResult(error('e')).unwrapOr(99)).toBe(99)
   })
 })
 
@@ -250,30 +251,30 @@ describe('ResultAsync await', () => {
 
 describe('PixivError constructors', () => {
   it('rateLimitError', () => {
-    const e: PixivError = rateLimitError(5000)
-    expect(e.type).toBe('rate_limit')
-    if (e.type === 'rate_limit') expect(e.retryAfter).toBe(5000)
+    const error_: PixivError = rateLimitError(5000)
+    expect(error_.type).toBe('rate_limit')
+    if (error_.type === 'rate_limit') expect(error_.retryAfter).toBe(5000)
   })
 
   it('authFailedError', () => {
-    const e = authFailedError(401)
-    expect(e.type).toBe('auth_failed')
-    if (e.type === 'auth_failed') expect(e.status).toBe(401)
+    const error_ = authFailedError(401)
+    expect(error_.type).toBe('auth_failed')
+    if (error_.type === 'auth_failed') expect(error_.status).toBe(401)
   })
 
   it('networkError', () => {
     const cause = new Error('ECONNREFUSED')
-    const e = networkError(cause)
-    expect(e.type).toBe('network')
-    if (e.type === 'network') expect(e.cause).toBe(cause)
+    const error_ = networkError(cause)
+    expect(error_.type).toBe('network')
+    if (error_.type === 'network') expect(error_.cause).toBe(cause)
   })
 
   it('apiError', () => {
-    const e = apiError(404, { error: 'not found' })
-    expect(e.type).toBe('api_error')
-    if (e.type === 'api_error') {
-      expect(e.status).toBe(404)
-      expect(e.body).toEqual({ error: 'not found' })
+    const error_ = apiError(404, { error: 'not found' })
+    expect(error_.type).toBe('api_error')
+    if (error_.type === 'api_error') {
+      expect(error_.status).toBe(404)
+      expect(error_.body).toEqual({ error: 'not found' })
     }
   })
 })

--- a/packages/db-mysql/drizzle.config.ts
+++ b/packages/db-mysql/drizzle.config.ts
@@ -12,7 +12,7 @@ import { defineConfig } from 'drizzle-kit'
 // process is a Node.js global. @types/node is not available in the default
 // TypeScript project used for this file (it is outside tsconfig include), so
 // we cast to a minimal shape to satisfy ESLint's type-aware rules.
-const env = (
+const environment = (
   process as unknown as { env: Record<string, string | undefined> }
 ).env
 
@@ -21,10 +21,10 @@ export default defineConfig({
   out: './drizzle',
   dialect: 'mysql',
   dbCredentials: {
-    host: env.RESPONSE_DB_HOSTNAME ?? 'localhost',
-    port: Number.parseInt(env.RESPONSE_DB_PORT ?? '3306', 10),
-    user: env.RESPONSE_DB_USERNAME ?? 'root',
-    password: env.RESPONSE_DB_PASSWORD ?? '',
-    database: env.RESPONSE_DB_DATABASE ?? 'pixivts',
+    host: environment.RESPONSE_DB_HOSTNAME ?? 'localhost',
+    port: Number(environment.RESPONSE_DB_PORT ?? '3306'),
+    user: environment.RESPONSE_DB_USERNAME ?? 'root',
+    password: environment.RESPONSE_DB_PASSWORD ?? '',
+    database: environment.RESPONSE_DB_DATABASE ?? 'pixivts',
   },
 })

--- a/packages/db-mysql/src/connection.ts
+++ b/packages/db-mysql/src/connection.ts
@@ -46,11 +46,18 @@ export interface ConnectionOptions {
  *
  * Typed with the `schema` so that relational queries are available.
  */
-export type DbInstance = ReturnType<typeof drizzle<typeof schema>>
+export type DatabaseInstance = ReturnType<typeof drizzle<typeof schema>>
+
+/**
+ * @deprecated Use {@link DatabaseInstance} instead. Kept as a type alias for
+ * backward compatibility with the pre-1.x `DbInstance` naming (renamed to
+ * `DatabaseInstance` to satisfy the `unicorn/name-replacements` lint rule).
+ */
+export type DbInstance = DatabaseInstance
 
 function parsePort(value: string | undefined): number {
   if (!value) return 3306
-  const parsed = Number.parseInt(value, 10)
+  const parsed = Number(value)
   return Number.isNaN(parsed) ? 3306 : parsed
 }
 
@@ -58,19 +65,19 @@ function parsePort(value: string | undefined): number {
  * Creates a mysql2 connection pool and returns both the raw pool and the
  * Drizzle ORM wrapper.
  *
- * @param opts - Connection options (fall back to environment variables)
+ * @param options - Connection options (fall back to environment variables)
  * @returns `{ pool, db }` — raw pool for `close()`, db for queries
  */
-export function createDbConnection(opts: ConnectionOptions): {
+export function createDatabaseConnection(options: ConnectionOptions): {
   pool: mysql.Pool
-  db: DbInstance
+  db: DatabaseInstance
 } {
   const pool = mysql.createPool({
-    host: opts.host ?? process.env.RESPONSE_DB_HOSTNAME ?? 'localhost',
-    port: opts.port ?? parsePort(process.env.RESPONSE_DB_PORT),
-    user: opts.user ?? process.env.RESPONSE_DB_USERNAME,
-    password: opts.password ?? process.env.RESPONSE_DB_PASSWORD,
-    database: opts.database ?? process.env.RESPONSE_DB_DATABASE,
+    host: options.host ?? process.env.RESPONSE_DB_HOSTNAME ?? 'localhost',
+    port: options.port ?? parsePort(process.env.RESPONSE_DB_PORT),
+    user: options.user ?? process.env.RESPONSE_DB_USERNAME,
+    password: options.password ?? process.env.RESPONSE_DB_PASSWORD,
+    database: options.database ?? process.env.RESPONSE_DB_DATABASE,
     timezone: '+09:00',
     supportBigNumbers: true,
     bigNumberStrings: true,
@@ -79,6 +86,21 @@ export function createDbConnection(opts: ConnectionOptions): {
   // Type assertion required: pnpm's peer-dep resolution for the patched drizzle-orm
   // creates a structurally-incompatible Pool type for the $client property.
   // The runtime value is correct; only the declaration paths differ.
-  const db = drizzle(pool, { schema, mode: 'default' }) as unknown as DbInstance
-  return { pool, db }
+  const database = drizzle(pool, {
+    schema,
+    mode: 'default',
+  }) as unknown as DatabaseInstance
+  return { pool, db: database }
+}
+
+/**
+ * @deprecated Use {@link createDatabaseConnection} instead. Kept as a wrapper
+ * for backward compatibility with the pre-1.x `createDbConnection` naming
+ * (renamed to satisfy the `unicorn/name-replacements` lint rule).
+ */
+export function createDbConnection(options: ConnectionOptions): {
+  pool: mysql.Pool
+  db: DatabaseInstance
+} {
+  return createDatabaseConnection(options)
 }

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -21,8 +21,16 @@
  */
 
 // Connection
+export { createDatabaseConnection } from './connection'
+export type { ConnectionOptions, DatabaseInstance } from './connection'
+
+// Deprecated aliases for the connection API above, kept for backward
+// compatibility with the pre-1.x `createDbConnection`/`DbInstance` naming
+// (renamed to satisfy the `unicorn/name-replacements` lint rule).
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- re-exporting the deprecated binding itself for backward compatibility, not using it
 export { createDbConnection } from './connection'
-export type { ConnectionOptions, DbInstance } from './connection'
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- re-exporting the deprecated alias itself for backward compatibility, not using it
+export type { DbInstance } from './connection'
 
 // Schema
 export { responsesTable } from './schema'

--- a/packages/db-mysql/src/migrations.ts
+++ b/packages/db-mysql/src/migrations.ts
@@ -10,7 +10,7 @@
  */
 
 import { sql } from 'drizzle-orm'
-import type { DbInstance } from './connection'
+import type { DatabaseInstance } from './connection'
 
 /**
  * Creates the `responses` table if it does not already exist.
@@ -18,10 +18,12 @@ import type { DbInstance } from './connection'
  * This is a lightweight alternative to running drizzle-kit migrations in
  * environments where the table has not been set up yet.
  *
- * @param db - Drizzle ORM database instance
+ * @param database - Drizzle ORM database instance
  */
-export async function bootstrapSchema(db: DbInstance): Promise<void> {
-  await db.execute(sql`
+export async function bootstrapSchema(
+  database: DatabaseInstance
+): Promise<void> {
+  await database.execute(sql`
     CREATE TABLE IF NOT EXISTS responses (
       id           INT AUTO_INCREMENT PRIMARY KEY COMMENT 'Response ID',
       method       VARCHAR(10)   NOT NULL COMMENT 'HTTP method',

--- a/packages/db-mysql/src/recorder.ts
+++ b/packages/db-mysql/src/recorder.ts
@@ -13,7 +13,11 @@
 import crypto from 'node:crypto'
 import { and, count, desc, eq, gte, sql } from 'drizzle-orm'
 import type { ResponseInterceptor, ResponseRecord } from '@book000/pixivts'
-import { createDbConnection, type ConnectionOptions, type DbInstance } from './connection'
+import {
+  createDatabaseConnection,
+  type ConnectionOptions,
+  type DatabaseInstance,
+} from './connection'
 import { responsesTable, type ResponseRow } from './schema'
 import { bootstrapSchema } from './migrations'
 
@@ -30,7 +34,7 @@ export interface RecorderBundle {
   interceptor: ResponseInterceptor
 
   /** Drizzle ORM database instance for custom queries. */
-  db: DbInstance
+  db: DatabaseInstance
 
   /** Closes the underlying connection pool. */
   close(): Promise<void>
@@ -91,21 +95,18 @@ function ninetyDaysAgo(): Date {
  * If the unique composite index fires (duplicate method + endpoint + statusCode
  * + urlHash), the insert is silently ignored via `ON DUPLICATE KEY UPDATE id = id`.
  *
- * @param db - Drizzle ORM database instance
+ * @param database - Drizzle ORM database instance
  * @param record - Response record from the HTTP client interceptor
  */
 export async function addResponse(
-  db: DbInstance,
+  database: DatabaseInstance,
   record: ResponseRecord
 ): Promise<void> {
   // Hash the URL if present; fall back to "method:endpoint" so the column is never empty.
   const urlToHash = record.url ?? `${record.method}:${record.endpoint}`
-  const urlHash = crypto
-    .createHash('sha256')
-    .update(urlToHash)
-    .digest('hex')
+  const urlHash = crypto.createHash('sha256').update(urlToHash).digest('hex')
 
-  await db
+  await database
     .insert(responsesTable)
     .values({
       method: record.method,
@@ -128,23 +129,23 @@ export async function addResponse(
  *
  * Useful for testing — pass a mock `db` and a no-op `close`.
  *
- * @param db - Drizzle ORM database instance
+ * @param database - Drizzle ORM database instance
  * @param close - Function that closes the underlying connection
  */
 export function createRecorderBundle(
-  db: DbInstance,
+  database: DatabaseInstance,
   close: () => Promise<void>
 ): RecorderBundle {
   const interceptor: ResponseInterceptor = (record) =>
-    addResponse(db, record)
+    addResponse(database, record)
 
-  return { interceptor, db, close }
+  return { interceptor, db: database, close }
 }
 
 /**
  * Creates a response recorder that persists every pixiv API response to MySQL.
  *
- * @param opts - Connection and bootstrapping options
+ * @param options - Connection and bootstrapping options
  * @returns `{ interceptor, db, close }`
  *
  * @example
@@ -160,11 +161,11 @@ export function createRecorderBundle(
  * ```
  */
 export async function createResponseRecorder(
-  opts: RecorderOptions
+  options: RecorderOptions
 ): Promise<RecorderBundle> {
-  const { pool, db } = createDbConnection(opts)
+  const { pool, db } = createDatabaseConnection(options)
 
-  if (opts.bootstrap) {
+  if (options.bootstrap) {
     await bootstrapSchema(db)
   }
 
@@ -196,13 +197,13 @@ export interface RangeOptions {
 /**
  * Retrieves response records from the last 90 days.
  *
- * @param db - Drizzle ORM database instance
+ * @param database - Drizzle ORM database instance
  * @param filter - Optional filter criteria
  * @param range - Optional pagination options
  * @returns Array of response rows, newest first
  */
 export async function getResponses(
-  db: DbInstance,
+  database: DatabaseInstance,
   filter?: ResponseFilter,
   range?: RangeOptions
 ): Promise<ResponseRow[]> {
@@ -210,15 +211,13 @@ export async function getResponses(
   const limit = range?.limit ?? 100
   const offset = ((range?.page ?? 1) - 1) * limit
 
-  return db
+  return database
     .select()
     .from(responsesTable)
     .where(
       and(
         gte(responsesTable.createdAt, since),
-        filter?.method
-          ? eq(responsesTable.method, filter.method)
-          : undefined,
+        filter?.method ? eq(responsesTable.method, filter.method) : undefined,
         filter?.endpoint
           ? eq(responsesTable.endpoint, filter.endpoint)
           : undefined,
@@ -235,24 +234,22 @@ export async function getResponses(
 /**
  * Returns the total count of response records from the last 90 days.
  *
- * @param db - Drizzle ORM database instance
+ * @param database - Drizzle ORM database instance
  * @param filter - Optional filter criteria
  * @returns Total row count matching the filter
  */
 export async function getResponseCount(
-  db: DbInstance,
+  database: DatabaseInstance,
   filter?: ResponseFilter
 ): Promise<number> {
   const since = ninetyDaysAgo()
-  const rows = await db
+  const rows = await database
     .select({ value: count() })
     .from(responsesTable)
     .where(
       and(
         gte(responsesTable.createdAt, since),
-        filter?.method
-          ? eq(responsesTable.method, filter.method)
-          : undefined,
+        filter?.method ? eq(responsesTable.method, filter.method) : undefined,
         filter?.endpoint
           ? eq(responsesTable.endpoint, filter.endpoint)
           : undefined,
@@ -280,12 +277,14 @@ export interface EndpointWithCount {
  * Returns all unique (method, endpoint, statusCode) combinations seen in the
  * last 90 days, along with the count of matching records.
  *
- * @param db - Drizzle ORM database instance
+ * @param database - Drizzle ORM database instance
  * @returns Endpoints sorted by count descending
  */
-export async function getEndpoints(db: DbInstance): Promise<EndpointWithCount[]> {
+export async function getEndpoints(
+  database: DatabaseInstance
+): Promise<EndpointWithCount[]> {
   const since = ninetyDaysAgo()
-  const rows = await db
+  const rows = await database
     .select({
       method: responsesTable.method,
       endpoint: responsesTable.endpoint,

--- a/packages/db-mysql/tests/integration/recorder.integration.test.ts
+++ b/packages/db-mysql/tests/integration/recorder.integration.test.ts
@@ -40,7 +40,7 @@ import type { ResponseRecord } from '@book000/pixivts'
 // Skip guard
 // ---------------------------------------------------------------------------
 
-const SKIP = !process.env.RESPONSE_DB_USERNAME
+const IS_SKIP = !process.env.RESPONSE_DB_USERNAME
 
 // ---------------------------------------------------------------------------
 // Test endpoints (isolated from production data via unusual paths)
@@ -73,7 +73,7 @@ function makeRecord(overrides: Partial<ResponseRecord> = {}): ResponseRecord {
 // Suite
 // ---------------------------------------------------------------------------
 
-describe.skipIf(SKIP)('db-mysql integration', () => {
+describe.skipIf(IS_SKIP)('db-mysql integration', () => {
   let bundle: RecorderBundle
 
   beforeAll(async () => {
@@ -149,9 +149,9 @@ describe.skipIf(SKIP)('db-mysql integration', () => {
 
   it('getResponses — returns rows ordered newest first', async () => {
     const rows = await getResponses(bundle.db, { endpoint: E2E_ENDPOINT_A })
-    for (let i = 1; i < rows.length; i++) {
-      expect(rows[i - 1].createdAt.getTime()).toBeGreaterThanOrEqual(
-        rows[i].createdAt.getTime()
+    for (let index = 1; index < rows.length; index++) {
+      expect(rows[index - 1].createdAt.getTime()).toBeGreaterThanOrEqual(
+        rows[index].createdAt.getTime()
       )
     }
   })
@@ -178,7 +178,7 @@ describe.skipIf(SKIP)('db-mysql integration', () => {
   it('getEndpoints — lists unique endpoints with counts', async () => {
     const endpoints = await getEndpoints(bundle.db)
     const entry = endpoints.find(
-      (e) => e.endpoint === E2E_ENDPOINT_A && e.method === 'GET'
+      (item) => item.endpoint === E2E_ENDPOINT_A && item.method === 'GET'
     )
     expect(entry).toBeDefined()
     expect(entry?.count).toBeGreaterThanOrEqual(1)
@@ -187,8 +187,10 @@ describe.skipIf(SKIP)('db-mysql integration', () => {
 
   it('getEndpoints — results are sorted by count descending', async () => {
     const endpoints = await getEndpoints(bundle.db)
-    for (let i = 1; i < endpoints.length; i++) {
-      expect(endpoints[i - 1].count).toBeGreaterThanOrEqual(endpoints[i].count)
+    for (let index = 1; index < endpoints.length; index++) {
+      expect(endpoints[index - 1].count).toBeGreaterThanOrEqual(
+        endpoints[index].count
+      )
     }
   })
 })

--- a/packages/db-mysql/tests/recorder.test.ts
+++ b/packages/db-mysql/tests/recorder.test.ts
@@ -10,7 +10,11 @@ import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { drizzle } from 'drizzle-orm/mysql2'
 import type { ResponseRecord } from '@book000/pixivts'
 import * as schema from '../src/schema'
-import { addResponse, createRecorderBundle, createResponseRecorder } from '../src/recorder'
+import {
+  addResponse,
+  createRecorderBundle,
+  createResponseRecorder,
+} from '../src/recorder'
 
 // ---------------------------------------------------------------------------
 // Hoisted mock state — created before vi.mock() factory runs
@@ -65,7 +69,9 @@ function sha256(input: string): string {
 
 describe('URL hash computation', () => {
   it('SHA-256 produces a 64-char hex string', () => {
-    const hash = sha256('https://app-api.pixiv.net/v1/illust/detail?illust_id=1')
+    const hash = sha256(
+      'https://app-api.pixiv.net/v1/illust/detail?illust_id=1'
+    )
     expect(hash).toHaveLength(64)
     expect(hash).toMatch(/^[\da-f]{64}$/)
   })
@@ -88,28 +94,28 @@ describe('URL hash computation', () => {
 
 describe('createRecorderBundle()', () => {
   it('returns an object with interceptor, db, and close', () => {
-    const db = drizzle.mock({ schema, mode: 'default' })
+    const database = drizzle.mock({ schema, mode: 'default' })
     const close = vi.fn().mockResolvedValue(undefined)
-    const bundle = createRecorderBundle(db as never, close)
+    const bundle = createRecorderBundle(database as never, close)
 
     expect(typeof bundle.interceptor).toBe('function')
-    expect(bundle.db).toBe(db)
+    expect(bundle.db).toBe(database)
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(bundle.close).toBe(close)
   })
 
   it('close() calls the provided close function exactly once', async () => {
-    const db = drizzle.mock({ schema, mode: 'default' })
+    const database = drizzle.mock({ schema, mode: 'default' })
     const close = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
-    const bundle = createRecorderBundle(db as never, close)
+    const bundle = createRecorderBundle(database as never, close)
 
     await bundle.close()
     expect(close).toHaveBeenCalledOnce()
   })
 
   it('interceptor is a function that returns a Promise', async () => {
-    const db = drizzle.mock({ schema, mode: 'default' })
-    const bundle = createRecorderBundle(db as never, vi.fn())
+    const database = drizzle.mock({ schema, mode: 'default' })
+    const bundle = createRecorderBundle(database as never, vi.fn())
     const record = makeRecord()
 
     const result = bundle.interceptor(record)
@@ -117,7 +123,11 @@ describe('createRecorderBundle()', () => {
     // Swallow any rejection from the mock db (no real session).
     // Cast to Promise<unknown> because the Drizzle mock's return type is not
     // fully resolved in the default TypeScript project (no tsconfig include).
-    await (result as Promise<unknown>).catch(() => undefined)
+    try {
+      await (result as Promise<unknown>)
+    } catch {
+      // Expected: the mock db has no real session to execute against.
+    }
   })
 })
 
@@ -128,7 +138,7 @@ describe('createRecorderBundle()', () => {
 describe('addResponse()', () => {
   it('does not throw when the mock db accepts the insert', async () => {
     // Spy on the Drizzle mock's query execution path
-    const db = drizzle.mock({ schema, mode: 'default' })
+    const database = drizzle.mock({ schema, mode: 'default' })
     const record = makeRecord()
 
     // Drizzle mock will throw "No client found" when actually executed.
@@ -136,7 +146,7 @@ describe('addResponse()', () => {
     // Drizzle internal error — not a hash computation error).
     let caughtError: unknown = null
     try {
-      await addResponse(db as never, record)
+      await addResponse(database as never, record)
     } catch (error: unknown) {
       caughtError = error
     }
@@ -144,12 +154,12 @@ describe('addResponse()', () => {
     // The error (if any) should come from Drizzle's mock client, not from
     // our urlHash logic or other preprocessing.
     if (caughtError !== null) {
-      const errMsg =
+      const errorMessage =
         caughtError instanceof Error
           ? caughtError.message
           : JSON.stringify(caughtError)
-      expect(errMsg).not.toContain('urlHash')
-      expect(errMsg).not.toContain('Cannot read')
+      expect(errorMessage).not.toContain('urlHash')
+      expect(errorMessage).not.toContain('Cannot read')
     }
   })
 })
@@ -164,7 +174,10 @@ describe('createResponseRecorder()', () => {
     mockExecute.mockReset()
     mockEnd.mockReset()
     // db.execute(sql`DDL`) goes through client.query() (text protocol)
-    const okPacket = [{ insertId: 0, affectedRows: 0, fieldCount: 0, serverStatus: 2 }, []]
+    const okPacket = [
+      { insertId: 0, affectedRows: 0, fieldCount: 0, serverStatus: 2 },
+      [],
+    ]
     mockQuery.mockResolvedValue(okPacket)
     // db.insert/select goes through client.execute() (prepared statements)
     mockExecute.mockResolvedValue(okPacket)
@@ -201,14 +214,14 @@ describe('createResponseRecorder()', () => {
     // Drizzle's db.execute(sql`DDL`) uses client.query() (text protocol), not client.execute().
     // Drizzle passes the query as an object: { sql: string, values: unknown[] }
     expect(mockQuery).toHaveBeenCalled()
-    const allArgs = mockQuery.mock.calls as unknown[][]
-    const sqlTexts = allArgs.map((args) => {
-      const arg = args[0]
-      if (typeof arg === 'string') return arg.toLowerCase()
-      if (arg && typeof arg === 'object' && 'sql' in arg) {
-        return (arg as { sql: string }).sql.toLowerCase()
+    const allArguments = mockQuery.mock.calls as unknown[][]
+    const sqlTexts = allArguments.map((arguments_) => {
+      const argument = arguments_[0]
+      if (typeof argument === 'string') return argument.toLowerCase()
+      if (argument && typeof argument === 'object' && 'sql' in argument) {
+        return (argument as { sql: string }).sql.toLowerCase()
       }
-      return JSON.stringify(arg).toLowerCase()
+      return JSON.stringify(argument).toLowerCase()
     })
     const hasCreateTable = sqlTexts.some(
       (s) => s.includes('create table if not exists') && s.includes('responses')

--- a/scripts/check-dts-no-zod.mjs
+++ b/scripts/check-dts-no-zod.mjs
@@ -48,22 +48,24 @@ const ZOD_PATTERNS = [
   /require\(['"]zod['"]\)/,
 ]
 
-let hadError = false
+let isHadError = false
 
 for (const file of collectDts(CORE_DIST)) {
   const content = readFileSync(file, 'utf8')
-  for (const pattern of ZOD_PATTERNS) {
-    if (pattern.test(content)) {
-      console.error(
-        `ERROR: zod reference found in ${nodePath.relative(process.cwd(), file)}`
-      )
-      console.error(`  Pattern: ${pattern}`)
-      hadError = true
-    }
+  const matchedPatterns = ZOD_PATTERNS.filter((pattern) =>
+    pattern.test(content)
+  )
+
+  for (const pattern of matchedPatterns) {
+    console.error(
+      `ERROR: zod reference found in ${nodePath.relative(process.cwd(), file)}`
+    )
+    console.error(`  Pattern: ${pattern}`)
+    isHadError = true
   }
 }
 
-if (hadError) {
+if (isHadError) {
   console.error(
     '\nzod leaked into the distributed .d.ts files. ' +
       'Ensure all public types are exported as type-only re-exports of z.infer<> results ' +

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2024", "ESNext.Array", "DOM"],
     "module": "ES2022",
     "moduleResolution": "bundler",
     "strict": true,


### PR DESCRIPTION
## Summary

Fixes lint failures that Renovate PR #1686 (`@book000/eslint-config` 1.15.4 -> 1.15.44) exposes. The bumped config pulls in a newer `eslint-plugin-unicorn` ruleset that flags roughly 190 pre-existing violations across the codebase.

## Changes

- Renamed abbreviated identifiers to satisfy `unicorn/name-replacements` (e.g. `ErrResult` -> `ErrorResult`, `DbInstance` -> `DatabaseInstance`, `createDbConnection` -> `createDatabaseConnection`, `*Params` -> `*Parameters` interfaces). Old names are kept as `@deprecated` aliases in the public barrel (`src/index.ts`) so the published npm package's API remains backward compatible.
- Replaced `.then()`/`.catch()` chains with `async`/`await` per `unicorn/prefer-await` where semantically possible.
- Extracted nested calls, wrapped bare callback references (`unicorn/no-array-callback-reference`), and clarified `for await` iterable expressions (`unicorn/no-unreadable-for-of-expression`).
- Replaced manual accumulation loops with `Array.fromAsync` (`unicorn/prefer-array-from-async`); added `ESNext.Array` to `tsconfig.base.json`'s `lib` array to support it.
- Minor fixes for `unicorn/prefer-number-coercion`, `unicorn/no-break-in-nested-loop`, `no-void`, `@typescript-eslint/no-deprecated`, `@typescript-eslint/no-unnecessary-type-assertion`.

## Notes

- No `eslint-disable` comments were carried over from the newer eslint-config unless verified valid under the currently pinned `1.15.4` version (some rule IDs referenced by the newer ruleset don't exist yet under 1.15.4 and would themselves error).
- `pnpm lint` and `pnpm test` both pass on this branch.
