### PR TITLE
fix(lint): resolve unicorn lint rules exposed by eslint-config v1.16.x

### DIFF
--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -9,7 +9,12 @@
  */
 
 import type { AuthManager } from './auth'
-import { apiError, authFailedError, networkError, rateLimitError } from './errors'
+import {
+  apiError,
+  authFailedError,
+  networkError,
+  rateLimitError,
+} from './errors'
 import type { ResponseInterceptor } from './interceptor'
 import { type HttpMethod, type ResponseRecord } from './interceptor'
 import { camelizeKeys } from './params'
@@ -86,11 +91,7 @@ export function parseRetryAfter(
 }
 
 function headersToRecord(headers: Headers): Record<string, string> {
-  const result: Record<string, string> = {}
-  for (const [key, value] of headers) {
-    result[key] = value
-  }
-  return result
+  return Object.fromEntries(headers)
 }
 
 /**
@@ -165,11 +166,11 @@ export class HttpClient {
       networkError
     ).andThen((response) => {
       if (!response.ok) {
-        return ResultAsync.fromResult(
-          err(apiError(response.status, null))
-        )
+        return ResultAsync.fromResult(err(apiError(response.status, null)))
       }
-      return ResultAsync.fromResult(ok(response) as Result<Response, PixivError>)
+      return ResultAsync.fromResult(
+        ok(response) as Result<Response, PixivError>
+      )
     })
   }
 
@@ -221,9 +222,9 @@ export class HttpClient {
       const requestHeaders: Record<string, string> = {
         ...DEFAULT_HEADERS,
         Authorization: `Bearer ${this.#auth.accessToken}`,
-        ...(method === 'POST'
-          ? { 'Content-Type': 'application/x-www-form-urlencoded' }
-          : {}),
+        ...(method === 'POST' && {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        }),
       }
 
       let response: Response

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -28,22 +28,18 @@ export function camelToSnake(key: string): string {
  * @param obj - Object with camelCase keys
  * @returns New object with snake_case keys
  */
-export function toSnakeKeys(obj: Record<string, unknown>): Record<string, unknown> {
+export function toSnakeKeys(
+  obj: Record<string, unknown>
+): Record<string, unknown> {
   const out: Record<string, unknown> = {}
-  for (const key of Object.keys(obj)) {
-    out[camelToSnake(key)] = obj[key]
+  for (const [key, value] of Object.entries(obj)) {
+    out[camelToSnake(key)] = value
   }
   return out
 }
 
 type ParamValue =
-  | string
-  | number
-  | boolean
-  | null
-  | undefined
-  | string[]
-  | number[]
+  string | number | boolean | null | undefined | string[] | number[]
 
 /**
  * Serialises a record of query parameters into a `URLSearchParams` instance.
@@ -198,7 +194,9 @@ export function parseNextUrl(url: string): ParsedNextUrl {
   if (maxBookmarkIdForRecommend !== undefined)
     result.maxBookmarkIdForRecommend = maxBookmarkIdForRecommend
 
-  const minBookmarkIdForRecentIllust = toNum('min_bookmark_id_for_recent_illust')
+  const minBookmarkIdForRecentIllust = toNum(
+    'min_bookmark_id_for_recent_illust'
+  )
   if (minBookmarkIdForRecentIllust !== undefined)
     result.minBookmarkIdForRecentIllust = minBookmarkIdForRecentIllust
 

--- a/packages/core/src/resources/illusts.ts
+++ b/packages/core/src/resources/illusts.ts
@@ -164,7 +164,10 @@ export class IllustResource {
   ): ResultAsync<IllustDetailResponse, PixivError> {
     return this.#http.get<IllustDetailResponse>(
       '/v1/illust/detail',
-      buildParams({ illustId: params.illustId, filter: params.filter ?? 'for_ios' })
+      buildParams({
+        illustId: params.illustId,
+        filter: params.filter ?? 'for_ios',
+      })
     )
   }
 
@@ -183,9 +186,7 @@ export class IllustResource {
         buildParams({
           illustId: params.illustId,
           filter: params.filter ?? 'for_ios',
-          ...(params.seedIllustIds
-            ? { seedIllustIds: params.seedIllustIds }
-            : {}),
+          ...(params.seedIllustIds && { seedIllustIds: params.seedIllustIds }),
         })
       ),
       this.#http,
@@ -284,7 +285,7 @@ export class IllustResource {
           offset: params.offset,
           maxBookmarkIdForRecommend: params.maxBookmarkIdForRecommend,
           minBookmarkIdForRecentIllust: params.minBookmarkIdForRecentIllust,
-          ...(params.viewed ? { viewed: params.viewed } : {}),
+          ...(params.viewed && { viewed: params.viewed }),
         })
       ),
       this.#http,
@@ -329,7 +330,7 @@ export class IllustResource {
     const body = buildParams({
       illustId: params.illustId,
       restrict: params.restrict ?? 'public',
-      ...(params.tags ? { tags: params.tags } : {}),
+      ...(params.tags && { tags: params.tags }),
     })
     return this.#http.post<Record<string, never>>(
       '/v2/illust/bookmark/add',

--- a/packages/core/src/resources/novels.ts
+++ b/packages/core/src/resources/novels.ts
@@ -305,7 +305,7 @@ export class NovelResource {
     const body = buildParams({
       novelId: params.novelId,
       restrict: params.restrict ?? 'public',
-      ...(params.tags ? { tags: params.tags } : {}),
+      ...(params.tags && { tags: params.tags }),
     })
     return this.#http.post<Record<string, never>>(
       '/v2/novel/bookmark/add',

--- a/packages/core/tests/client.test.ts
+++ b/packages/core/tests/client.test.ts
@@ -145,26 +145,21 @@ describe('illusts.search().pages() — multi-page', () => {
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
         HttpResponse.json(AUTH_RESPONSE)
       ),
-      http.get(
-        'https://app-api.pixiv.net/v1/search/illust',
-        ({ request }) => {
-          const offset = new URL(request.url).searchParams.get('offset')
-          if (offset === '30') {
-            return HttpResponse.json({ illusts: [ILLUST2], next_url: null })
-          }
-          return HttpResponse.json({
-            illusts: [ILLUST],
-            next_url:
-              'https://app-api.pixiv.net/v1/search/illust?offset=30',
-          })
+      http.get('https://app-api.pixiv.net/v1/search/illust', ({ request }) => {
+        const offset = new URL(request.url).searchParams.get('offset')
+        if (offset === '30') {
+          return HttpResponse.json({ illusts: [ILLUST2], next_url: null })
         }
-      )
+        return HttpResponse.json({
+          illusts: [ILLUST],
+          next_url: 'https://app-api.pixiv.net/v1/search/illust?offset=30',
+        })
+      })
     )
     const client = await PixivClient.of('test-refresh-token')
     const pages: number[] = []
-    for await (const page of client.illusts
-      .search({ word: 'cat' })
-      .pages()) {
+    const pageIterable = client.illusts.search({ word: 'cat' }).pages()
+    for await (const page of pageIterable) {
       pages.push(page.illusts.length)
     }
     expect(pages).toHaveLength(2)
@@ -182,29 +177,24 @@ describe('illusts.search().items() — multi-page', () => {
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
         HttpResponse.json(AUTH_RESPONSE)
       ),
-      http.get(
-        'https://app-api.pixiv.net/v1/search/illust',
-        ({ request }) => {
-          const offset = new URL(request.url).searchParams.get('offset')
-          if (offset === '30') {
-            return HttpResponse.json({
-              illusts: [ILLUST3, ILLUST4],
-              next_url: null,
-            })
-          }
+      http.get('https://app-api.pixiv.net/v1/search/illust', ({ request }) => {
+        const offset = new URL(request.url).searchParams.get('offset')
+        if (offset === '30') {
           return HttpResponse.json({
-            illusts: [ILLUST, ILLUST2],
-            next_url:
-              'https://app-api.pixiv.net/v1/search/illust?offset=30',
+            illusts: [ILLUST3, ILLUST4],
+            next_url: null,
           })
         }
-      )
+        return HttpResponse.json({
+          illusts: [ILLUST, ILLUST2],
+          next_url: 'https://app-api.pixiv.net/v1/search/illust?offset=30',
+        })
+      })
     )
     const client = await PixivClient.of('test-refresh-token')
     const ids: number[] = []
-    for await (const illust of client.illusts
-      .search({ word: 'cat' })
-      .items()) {
+    const itemIterable = client.illusts.search({ word: 'cat' }).items()
+    for await (const illust of itemIterable) {
       ids.push(illust.id)
     }
     expect(ids).toHaveLength(4)
@@ -219,14 +209,10 @@ describe('illusts.ranking()', () => {
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
         HttpResponse.json(AUTH_RESPONSE)
       ),
-      http.get(
-        'https://app-api.pixiv.net/v1/illust/ranking',
-        ({ request }) => {
-          capturedMode =
-            new URL(request.url).searchParams.get('mode') ?? ''
-          return HttpResponse.json({ illusts: [ILLUST], next_url: null })
-        }
-      )
+      http.get('https://app-api.pixiv.net/v1/illust/ranking', ({ request }) => {
+        capturedMode = new URL(request.url).searchParams.get('mode') ?? ''
+        return HttpResponse.json({ illusts: [ILLUST], next_url: null })
+      })
     )
     const client = await PixivClient.of('test-refresh-token')
     const result = await client.illusts.ranking({ mode: 'week' })
@@ -335,7 +321,9 @@ describe('illusts.recommended() — includeRankingLabel param', () => {
       )
     )
     const client = await PixivClient.of('test-refresh-token')
-    const result = await client.illusts.recommended({ includeRankingLabel: false })
+    const result = await client.illusts.recommended({
+      includeRankingLabel: false,
+    })
     expect(result.isOk).toBe(true)
     expect(capturedUrl).toBeDefined()
     if (capturedUrl === undefined) return
@@ -403,13 +391,11 @@ describe('illusts.recommended() — meta_single_page regression (PIXIVTS-39)', (
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
         HttpResponse.json(AUTH_RESPONSE)
       ),
-      http.get(
-        'https://app-api.pixiv.net/v1/illust/recommended',
-        () =>
-          HttpResponse.json({
-            ...RECOMMENDED_RESPONSE,
-            illusts: [MANGA_ILLUST],
-          })
+      http.get('https://app-api.pixiv.net/v1/illust/recommended', () =>
+        HttpResponse.json({
+          ...RECOMMENDED_RESPONSE,
+          illusts: [MANGA_ILLUST],
+        })
       )
     )
     const client = await PixivClient.of('test-refresh-token')
@@ -429,9 +415,8 @@ describe('illusts.bookmarkAdd()', () => {
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
         HttpResponse.json(AUTH_RESPONSE)
       ),
-      http.post(
-        'https://app-api.pixiv.net/v2/illust/bookmark/add',
-        () => HttpResponse.json({})
+      http.post('https://app-api.pixiv.net/v2/illust/bookmark/add', () =>
+        HttpResponse.json({})
       )
     )
     const client = await PixivClient.of('test-refresh-token')
@@ -669,10 +654,12 @@ describe('images.fetch()', () => {
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
         HttpResponse.json(AUTH_RESPONSE)
       ),
-      http.get(imageUrl, () =>
-        new HttpResponse(new Uint8Array([0xff, 0xd8]).buffer, {
-          headers: { 'Content-Type': 'image/jpeg' },
-        })
+      http.get(
+        imageUrl,
+        () =>
+          new HttpResponse(new Uint8Array([0xff, 0xd8]).buffer, {
+            headers: { 'Content-Type': 'image/jpeg' },
+          })
       )
     )
     const client = await PixivClient.of('test-refresh-token')

--- a/packages/core/tests/e2e/pixiv.e2e.test.ts
+++ b/packages/core/tests/e2e/pixiv.e2e.test.ts
@@ -430,9 +430,8 @@ describe.skipIf(SKIP)('PixivClient e2e', () => {
   it('PaginatedResultAsync.pages() — iterates at least one page', async () => {
     let pageCount = 0
     let totalIllusts = 0
-    for await (const page of client.illusts
-      .search({ word: 'ホロライブ' })
-      .pages()) {
+    const pageIterable = client.illusts.search({ word: 'ホロライブ' }).pages()
+    for await (const page of pageIterable) {
       pageCount++
       totalIllusts += page.illusts.length
       if (pageCount >= 2) break
@@ -443,9 +442,8 @@ describe.skipIf(SKIP)('PixivClient e2e', () => {
 
   it('PaginatedResultAsync.items() — yields individual items', async () => {
     const illusts: unknown[] = []
-    for await (const illust of client.illusts
-      .search({ word: 'ホロライブ' })
-      .items()) {
+    const itemIterable = client.illusts.search({ word: 'ホロライブ' }).items()
+    for await (const illust of itemIterable) {
       illusts.push(illust)
       if (illusts.length >= 60) break // stop after ~2 pages
     }

--- a/packages/core/tests/paginated.test.ts
+++ b/packages/core/tests/paginated.test.ts
@@ -26,7 +26,11 @@ interface ItemPage extends PagedResponse {
 // ---------------------------------------------------------------------------
 
 function makeAuth(): AuthManager {
-  return new AuthManager({ userId: '1', accessToken: 'token', refreshToken: 'rt' })
+  return new AuthManager({
+    userId: '1',
+    accessToken: 'token',
+    refreshToken: 'rt',
+  })
 }
 
 function makeHttp(): HttpClient {
@@ -83,10 +87,7 @@ describe('PaginatedResultAsync — single page', () => {
       (page) => page.items
     )
 
-    const collected: ItemPage[] = []
-    for await (const page of paginated.pages()) {
-      collected.push(page)
-    }
+    const collected = await Array.fromAsync(paginated.pages())
     expect(collected).toHaveLength(1)
     expect(collected[0].items[0].id).toBe(1)
   })
@@ -111,10 +112,7 @@ describe('PaginatedResultAsync — single page', () => {
       (page) => page.items
     )
 
-    const collected: Item[] = []
-    for await (const item of paginated.items()) {
-      collected.push(item)
-    }
+    const collected = await Array.fromAsync(paginated.items())
     expect(collected).toHaveLength(2)
     expect(collected.map((i) => i.id)).toEqual([1, 2])
   })
@@ -262,10 +260,7 @@ describe('PaginatedResultAsync — multiple pages', () => {
       (page) => page.items
     )
 
-    const pages: ItemPage[] = []
-    for await (const page of paginated.pages()) {
-      pages.push(page)
-    }
+    const pages = await Array.fromAsync(paginated.pages())
 
     expect(pages).toHaveLength(2)
     expect(fetchCount).toBe(2)

--- a/scripts/check-dts-no-zod.mjs
+++ b/scripts/check-dts-no-zod.mjs
@@ -53,13 +53,14 @@ let hadError = false
 for (const file of collectDts(CORE_DIST)) {
   const content = readFileSync(file, 'utf8')
   for (const pattern of ZOD_PATTERNS) {
-    if (pattern.test(content)) {
-      console.error(
-        `ERROR: zod reference found in ${nodePath.relative(process.cwd(), file)}`
-      )
-      console.error(`  Pattern: ${pattern}`)
-      hadError = true
+    if (!pattern.test(content)) {
+      continue
     }
+    console.error(
+      `ERROR: zod reference found in ${nodePath.relative(process.cwd(), file)}`
+    )
+    console.error(`  Pattern: ${pattern}`)
+    hadError = true
   }
 }
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022", "ESNext.Array", "DOM"],
     "module": "ES2022",
     "moduleResolution": "bundler",
     "strict": true,


### PR DESCRIPTION
## Summary

Renovate PR #1686 bumps `@book000/eslint-config` `1.15.4` -> `1.16.3`. The v1.16.x reorganization (explicit unicorn rule enumeration replacing flat/recommended defaults) flags a smaller, distinct set of pre-existing lint violations from the ruleset the config previously used.

Fixed, all mechanical, no behavior change:

- `unicorn/prefer-object-from-entries` — `headersToRecord` in `src/http.ts`
- `unicorn/consistent-conditional-object-spread` — ternary spreads converted to logical `&&` spreads (`http.ts`, `resources/illusts.ts`, `resources/novels.ts`)
- `unicorn/prefer-object-iterable-methods` — `Object.keys()` loop converted to `Object.entries()` in `params.ts`
- `unicorn/no-unreadable-for-of-expression` — chained iterable expressions extracted to a local variable before the `for await` header (`tests/client.test.ts`, `tests/e2e/pixiv.e2e.test.ts`)
- `unicorn/prefer-array-from-async` — accumulation loops converted to `Array.fromAsync()` in `tests/paginated.test.ts` (required adding `ESNext.Array` to `tsconfig.base.json`'s `lib`, since `Array.fromAsync` isn't declared under `ES2022`)
- `unicorn/prefer-continue` — early continue in `scripts/check-dts-no-zod.mjs`

Left as-is: an existing `eslint-disable-next-line unicorn/no-array-callback-reference` in `src/result.ts` — it becomes an unused-directive *warning* (not an error) under v1.16.3, but is still required to pass lint under the currently pinned v1.15.4, so it stays.

## Verification

- `pnpm lint` clean under both the currently pinned `@book000/eslint-config@1.15.4` and the Renovate PR's target `1.16.3` (0 errors either way; only the known pre-existing warning noted above under 1.16.3)
- `pnpm test`: 167/167 passed

This PR intentionally does **not** bump `@book000/eslint-config` itself — that stays with Renovate PR #1686.