### PR TITLE
feat(core): add novelComments, novelNew, novelFollow endpoints

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,7 @@ export type {
   MetaPages,
   IllustSeriesDetail,
   PixivNovelItem,
+  NovelComment,
   NovelSeriesDetail,
   PixivUserItem,
   PixivUserProfile,
@@ -77,6 +78,7 @@ export type {
   NovelListPage,
   NovelRecommendedPage,
   NovelSeriesPage,
+  NovelCommentsPage,
   UserDetailResponse,
   UserIllustsPage,
   UserNovelsPage,
@@ -107,6 +109,9 @@ export type {
   NovelSeriesParams,
   NovelBookmarkAddParams,
   NovelBookmarkDeleteParams,
+  NovelFollowParams,
+  NovelCommentsParams,
+  NovelNewParams,
 } from './resources/novels'
 
 export type {

--- a/packages/core/src/resources/novels.ts
+++ b/packages/core/src/resources/novels.ts
@@ -8,6 +8,7 @@ import { PaginatedResultAsync } from '../paginated'
 import type { ResultAsync } from '../result'
 import {
   BookmarkRestrict,
+  FollowRestrict,
   NovelRankingMode,
   OSFilter,
   SearchDuration,
@@ -15,6 +16,8 @@ import {
   SearchTarget,
 } from '../options'
 import type {
+  NovelComment,
+  NovelCommentsPage,
   NovelDetailResponse,
   NovelListPage,
   NovelRecommendedPage,
@@ -111,6 +114,32 @@ export interface NovelBookmarkAddParams {
 export interface NovelBookmarkDeleteParams {
   /** ID of the novel to remove from bookmarks. */
   novelId: number
+}
+
+/** Parameters for fetching novels posted by followed users. */
+export interface NovelFollowParams {
+  /** Follow visibility to fetch (default: `"public"`). */
+  restrict?: (typeof FollowRestrict)[keyof typeof FollowRestrict]
+  /** Zero-based offset for pagination. */
+  offset?: number
+}
+
+/** Parameters for fetching comments on a novel. */
+export interface NovelCommentsParams {
+  /** ID of the novel to fetch comments for. */
+  novelId: number
+  /** Zero-based offset for pagination. */
+  offset?: number
+  /** Whether to include the `totalComments` count in the response. */
+  includeTotalComments?: boolean
+}
+
+/** Parameters for fetching newly posted novels. */
+export interface NovelNewParams {
+  /** OS filter to apply (default: `"for_ios"`). */
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
+  /** Cursor: fetch novels posted before this novel ID. */
+  maxNovelId?: number
 }
 
 /** Methods for the novel API namespace. */
@@ -326,6 +355,73 @@ export class NovelResource {
     return this.#http.post<Record<string, never>>(
       '/v1/novel/bookmark/delete',
       body.toString()
+    )
+  }
+
+  /**
+   * Fetches novels posted by users the authenticated account follows.
+   * GET /v1/novel/follow
+   *
+   * @param params - Request parameters
+   */
+  follow(
+    params: NovelFollowParams = {}
+  ): PaginatedResultAsync<NovelListPage, PixivNovelItem> {
+    return PaginatedResultAsync.fromResultAsync(
+      this.#http.get<NovelListPage>(
+        '/v1/novel/follow',
+        buildParams({
+          restrict: params.restrict ?? 'public',
+          offset: params.offset,
+        })
+      ),
+      this.#http,
+      (page) => page.novels
+    )
+  }
+
+  /**
+   * Fetches comments posted on a novel.
+   * GET /v1/novel/comments
+   *
+   * @param params - Request parameters
+   */
+  comments(
+    params: NovelCommentsParams
+  ): PaginatedResultAsync<NovelCommentsPage, NovelComment> {
+    return PaginatedResultAsync.fromResultAsync(
+      this.#http.get<NovelCommentsPage>(
+        '/v1/novel/comments',
+        buildParams({
+          novelId: params.novelId,
+          offset: params.offset,
+          includeTotalComments: params.includeTotalComments,
+        })
+      ),
+      this.#http,
+      (page) => page.comments
+    )
+  }
+
+  /**
+   * Fetches newly posted novels.
+   * GET /v1/novel/new
+   *
+   * @param params - Request parameters
+   */
+  new(
+    params: NovelNewParams = {}
+  ): PaginatedResultAsync<NovelListPage, PixivNovelItem> {
+    return PaginatedResultAsync.fromResultAsync(
+      this.#http.get<NovelListPage>(
+        '/v1/novel/new',
+        buildParams({
+          filter: params.filter ?? 'for_ios',
+          maxNovelId: params.maxNovelId,
+        })
+      ),
+      this.#http,
+      (page) => page.novels
     )
   }
 }

--- a/packages/core/src/schemas/novel.ts
+++ b/packages/core/src/schemas/novel.ts
@@ -49,6 +49,27 @@ export const PixivNovelItemSchema = z.object({
   commentAccessControl: z.number().optional(),
 })
 
+/** A single comment on a novel. */
+export const NovelCommentSchema: z.ZodType<{
+  id: number
+  comment: string
+  date: string
+  user: z.infer<typeof PixivUserSchema>
+  hasReplies?: boolean
+  parentComment?: Record<string, never> | z.infer<typeof NovelCommentSchema>
+}> = z.lazy(() =>
+  z.object({
+    id: z.number(),
+    comment: z.string(),
+    date: z.string(),
+    user: PixivUserSchema,
+    hasReplies: z.boolean().optional(),
+    parentComment: z
+      .union([z.record(z.string(), z.never()), NovelCommentSchema])
+      .optional(),
+  })
+)
+
 /** Novel series details returned by GET /v2/novel/series. */
 export const NovelSeriesDetailSchema = z.object({
   id: z.number(),
@@ -66,4 +87,5 @@ export const NovelSeriesDetailSchema = z.object({
 })
 
 export type PixivNovelItem = z.infer<typeof PixivNovelItemSchema>
+export type NovelComment = z.infer<typeof NovelCommentSchema>
 export type NovelSeriesDetail = z.infer<typeof NovelSeriesDetailSchema>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -278,6 +278,26 @@ export interface PixivNovelItem {
   commentAccessControl?: number
 }
 
+/**
+ * A single comment on a novel.
+ *
+ * Returned by GET /v1/novel/comments.
+ */
+export interface NovelComment {
+  /** Comment ID. */
+  id: number
+  /** Comment body text. */
+  comment: string
+  /** ISO 8601 date-time string of when the comment was posted. */
+  date: string
+  /** Author of the comment. */
+  user: PixivUser
+  /** Whether this comment has replies. */
+  hasReplies?: boolean
+  /** The comment this is a reply to, or `{}` (empty object) for a top-level comment. */
+  parentComment?: NovelComment | Record<string, never>
+}
+
 /** Novel series details returned by GET /v2/novel/series. */
 export interface NovelSeriesDetail {
   /** Series ID. */
@@ -589,6 +609,18 @@ export interface NovelRecommendedPage {
   privacyPolicy?: PrivacyPolicy
   /** URL to the next page, or `null` when this is the last page. */
   nextUrl: string | null
+}
+
+/** Page response for GET /v1/novel/comments. */
+export interface NovelCommentsPage {
+  /** Total number of comments on the novel (present only when `includeTotalComments` is requested). */
+  totalComments?: number
+  /** Comments on this page. */
+  comments: NovelComment[]
+  /** URL to the next page, or `null` when this is the last page. */
+  nextUrl: string | null
+  /** Who is permitted to post comments (may be absent). */
+  commentAccessControl?: number
 }
 
 /** Page response for GET /v2/novel/series. */

--- a/packages/core/tests/client.test.ts
+++ b/packages/core/tests/client.test.ts
@@ -481,6 +481,41 @@ describe('novels.follow()', () => {
     }
     expect(capturedRestrict).toBe('public')
   })
+
+  it('sends restrict=private when explicitly requested', async () => {
+    let capturedRestrict = ''
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get('https://app-api.pixiv.net/v1/novel/follow', ({ request }) => {
+        capturedRestrict =
+          new URL(request.url).searchParams.get('restrict') ?? ''
+        return HttpResponse.json({ novels: [NOVEL], next_url: null })
+      })
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.novels.follow({ restrict: 'private' })
+    expect(result.isOk).toBe(true)
+    expect(capturedRestrict).toBe('private')
+  })
+
+  it('forwards the offset param', async () => {
+    let capturedOffset = ''
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get('https://app-api.pixiv.net/v1/novel/follow', ({ request }) => {
+        capturedOffset = new URL(request.url).searchParams.get('offset') ?? ''
+        return HttpResponse.json({ novels: [NOVEL], next_url: null })
+      })
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.novels.follow({ offset: 30 })
+    expect(result.isOk).toBe(true)
+    expect(capturedOffset).toBe('30')
+  })
 })
 
 describe('novels.comments()', () => {
@@ -517,6 +552,90 @@ describe('novels.comments()', () => {
       expect(result.value.comments[0].comment).toBe('Nice!')
     }
   })
+
+  it('forwards the offset param', async () => {
+    let capturedOffset = ''
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get('https://app-api.pixiv.net/v1/novel/comments', ({ request }) => {
+        capturedOffset = new URL(request.url).searchParams.get('offset') ?? ''
+        return HttpResponse.json({ comments: [], next_url: null })
+      })
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.novels.comments({ novelId: 100, offset: 10 })
+    expect(result.isOk).toBe(true)
+    expect(capturedOffset).toBe('10')
+  })
+
+  it('omits the includeTotalComments param when not requested', async () => {
+    let hasIncludeTotalComments = true
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get('https://app-api.pixiv.net/v1/novel/comments', ({ request }) => {
+        hasIncludeTotalComments = new URL(request.url).searchParams.has(
+          'include_total_comments'
+        )
+        return HttpResponse.json({ comments: [], next_url: null })
+      })
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.novels.comments({ novelId: 100 })
+    expect(result.isOk).toBe(true)
+    expect(hasIncludeTotalComments).toBe(false)
+  })
+
+  it('maps commentAccessControl, hasReplies, and a nested parentComment', async () => {
+    const PARENT_COMMENT = {
+      id: 1,
+      comment: 'Original comment',
+      date: '2024-01-01T00:00:00+09:00',
+      user: {
+        id: 98,
+        name: 'Original commenter',
+        account: 'original-commenter',
+        profile_image_urls: { medium: 'https://i.pximg.net/u1.jpg' },
+      },
+      parent_comment: {},
+    }
+    const REPLY_COMMENT = {
+      id: 2,
+      comment: 'A reply',
+      date: '2024-01-02T00:00:00+09:00',
+      user: {
+        id: 99,
+        name: 'Commenter',
+        account: 'commenter',
+        profile_image_urls: { medium: 'https://i.pximg.net/u2.jpg' },
+      },
+      has_replies: true,
+      parent_comment: PARENT_COMMENT,
+    }
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get('https://app-api.pixiv.net/v1/novel/comments', () =>
+        HttpResponse.json({
+          comments: [REPLY_COMMENT],
+          next_url: null,
+          comment_access_control: 1,
+        })
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.novels.comments({ novelId: 100 })
+    expect(result.isOk).toBe(true)
+    if (!result.isOk) return
+    expect(result.value.commentAccessControl).toBe(1)
+    const [reply] = result.value.comments
+    expect(reply.hasReplies).toBe(true)
+    expect(reply.parentComment).toMatchObject({ id: 1, comment: 'Original comment' })
+  })
 })
 
 describe('novels.new()', () => {
@@ -539,6 +658,23 @@ describe('novels.new()', () => {
       expect(result.value.novels).toHaveLength(1)
     }
     expect(capturedMaxNovelId).toBe('100')
+  })
+
+  it('defaults filter to for_ios when omitted', async () => {
+    let capturedFilter = ''
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get('https://app-api.pixiv.net/v1/novel/new', ({ request }) => {
+        capturedFilter = new URL(request.url).searchParams.get('filter') ?? ''
+        return HttpResponse.json({ novels: [NOVEL], next_url: null })
+      })
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.novels.new()
+    expect(result.isOk).toBe(true)
+    expect(capturedFilter).toBe('for_ios')
   })
 })
 

--- a/packages/core/tests/client.test.ts
+++ b/packages/core/tests/client.test.ts
@@ -460,6 +460,88 @@ describe('novels.detail()', () => {
   })
 })
 
+describe('novels.follow()', () => {
+  it('returns Ok with followed novels and defaults restrict to public', async () => {
+    let capturedRestrict = ''
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get('https://app-api.pixiv.net/v1/novel/follow', ({ request }) => {
+        capturedRestrict =
+          new URL(request.url).searchParams.get('restrict') ?? ''
+        return HttpResponse.json({ novels: [NOVEL], next_url: null })
+      })
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.novels.follow()
+    expect(result.isOk).toBe(true)
+    if (result.isOk) {
+      expect(result.value.novels).toHaveLength(1)
+    }
+    expect(capturedRestrict).toBe('public')
+  })
+})
+
+describe('novels.comments()', () => {
+  it('returns Ok with comments', async () => {
+    const COMMENT = {
+      id: 1,
+      comment: 'Nice!',
+      date: '2024-01-01T00:00:00+09:00',
+      user: {
+        id: 99,
+        name: 'Commenter',
+        account: 'commenter',
+        profile_image_urls: { medium: 'https://i.pximg.net/u2.jpg' },
+      },
+      parent_comment: {},
+    }
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get('https://app-api.pixiv.net/v1/novel/comments', () =>
+        HttpResponse.json({
+          total_comments: 1,
+          comments: [COMMENT],
+          next_url: null,
+        })
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.novels.comments({ novelId: 100 })
+    expect(result.isOk).toBe(true)
+    if (result.isOk) {
+      expect(result.value.totalComments).toBe(1)
+      expect(result.value.comments[0].comment).toBe('Nice!')
+    }
+  })
+})
+
+describe('novels.new()', () => {
+  it('passes the maxNovelId param in the URL', async () => {
+    let capturedMaxNovelId = ''
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get('https://app-api.pixiv.net/v1/novel/new', ({ request }) => {
+        capturedMaxNovelId =
+          new URL(request.url).searchParams.get('max_novel_id') ?? ''
+        return HttpResponse.json({ novels: [NOVEL], next_url: null })
+      })
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.novels.new({ maxNovelId: 100 })
+    expect(result.isOk).toBe(true)
+    if (result.isOk) {
+      expect(result.value.novels).toHaveLength(1)
+    }
+    expect(capturedMaxNovelId).toBe('100')
+  })
+})
+
 describe('users.detail()', () => {
   it('returns Ok with user detail', async () => {
     const profile = {

--- a/packages/core/tests/e2e/pixiv.e2e.test.ts
+++ b/packages/core/tests/e2e/pixiv.e2e.test.ts
@@ -319,10 +319,45 @@ describe.skipIf(SKIP)('PixivClient e2e', () => {
     expect(Array.isArray(result.value.novels)).toBe(true)
   })
 
+  it('novels.follow with restrict=private', async () => {
+    const result = await client.novels.follow({ restrict: 'private' })
+    expect(result.isOk).toBe(true)
+    if (!result.isOk) return
+    expect(Array.isArray(result.value.novels)).toBe(true)
+  })
+
+  it('novels.follow with offset', async () => {
+    const result = await client.novels.follow({ restrict: 'public', offset: 1 })
+    expect(result.isOk).toBe(true)
+    if (!result.isOk) return
+    expect(Array.isArray(result.value.novels)).toBe(true)
+  })
+
   it('novels.comments', async () => {
     const result = await client.novels.comments({
       novelId: NOVEL_ID,
       includeTotalComments: true,
+    })
+    expect(result.isOk).toBe(true)
+    if (!result.isOk) return
+    expect(Array.isArray(result.value.comments)).toBe(true)
+    expect(typeof result.value.totalComments).toBe('number')
+    if (result.value.commentAccessControl !== undefined) {
+      expect(typeof result.value.commentAccessControl).toBe('number')
+    }
+    if (result.value.comments.length > 0) {
+      const [comment] = result.value.comments
+      expect(typeof comment.id).toBe('number')
+      expect(typeof comment.comment).toBe('string')
+      expect(typeof comment.date).toBe('string')
+      expect(typeof comment.user.id).toBe('number')
+    }
+  })
+
+  it('novels.comments with offset', async () => {
+    const result = await client.novels.comments({
+      novelId: NOVEL_ID,
+      offset: 1,
     })
     expect(result.isOk).toBe(true)
     if (!result.isOk) return
@@ -334,6 +369,26 @@ describe.skipIf(SKIP)('PixivClient e2e', () => {
     expect(result.isOk).toBe(true)
     if (!result.isOk) return
     expect(result.value.novels.length).toBeGreaterThan(0)
+  })
+
+  it('novels.new resumes pagination via the maxNovelId cursor', async () => {
+    const first = await client.novels.new({})
+    expect(first.isOk).toBe(true)
+    if (!first.isOk) return
+    expect(first.value.novels.length).toBeGreaterThan(0)
+    if (first.value.nextUrl === null) return // no further pages to resume
+
+    // `next_url` embeds `max_novel_id`, but `ParsedNextUrl` does not expose
+    // it as a typed field — extract it manually from the raw URL.
+    const maxNovelId = Number(
+      new URL(first.value.nextUrl).searchParams.get('max_novel_id')
+    )
+    expect(Number.isNaN(maxNovelId)).toBe(false)
+
+    const second = await client.novels.new({ maxNovelId })
+    expect(second.isOk).toBe(true)
+    if (!second.isOk) return
+    expect(second.value.novels.length).toBeGreaterThan(0)
   })
 
   // -------------------------------------------------------------------------

--- a/packages/core/tests/e2e/pixiv.e2e.test.ts
+++ b/packages/core/tests/e2e/pixiv.e2e.test.ts
@@ -312,6 +312,30 @@ describe.skipIf(SKIP)('PixivClient e2e', () => {
     }
   })
 
+  it('novels.follow', async () => {
+    const result = await client.novels.follow({ restrict: 'public' })
+    expect(result.isOk).toBe(true)
+    if (!result.isOk) return
+    expect(Array.isArray(result.value.novels)).toBe(true)
+  })
+
+  it('novels.comments', async () => {
+    const result = await client.novels.comments({
+      novelId: NOVEL_ID,
+      includeTotalComments: true,
+    })
+    expect(result.isOk).toBe(true)
+    if (!result.isOk) return
+    expect(Array.isArray(result.value.comments)).toBe(true)
+  })
+
+  it('novels.new', async () => {
+    const result = await client.novels.new({})
+    expect(result.isOk).toBe(true)
+    if (!result.isOk) return
+    expect(result.value.novels.length).toBeGreaterThan(0)
+  })
+
   // -------------------------------------------------------------------------
   // Users
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add three previously unimplemented Novel API endpoints.

## Changes

- `novels.comments()` — `GET /v1/novel/comments` (fetch comments on a novel)
- `novels.new()` — `GET /v1/novel/new` (fetch newly posted novels)
- `novels.follow()` — `GET /v1/novel/follow` (fetch novels from followed users)
- Add `NovelComment` / `NovelCommentsPage` types with a matching zod schema
- Mirrors the existing `illusts.comments()` / `illusts.new()` / `illusts.follow()` implementation pattern
- Add unit tests (MSW) and e2e tests (live API) covering each new method, including default/optional params, offset-based pagination, `includeTotalComments` omission, nested `parentComment` field mapping, and `maxNovelId` cursor-based pagination

## Verification

- `pnpm build` — succeeds
- `pnpm lint` — no errors
- `pnpm test` (unit tests) — 176 tests passed
- `pnpm --filter @book000/pixivts build:dts-guard` — confirmed no zod references
- `pnpm --filter @book000/pixivts test:e2e` (live API) — 36 tests passed, including `novels.follow` / `novels.comments` / `novels.new` and their edge cases