### PR TITLE
feat(core): add users.search and illusts.trendingTags endpoints

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -72,9 +72,9 @@ Creates a `PixivClient` by exchanging the given refresh token for an access toke
 
 | Namespace | Methods |
 |---|---|
-| `illusts` | `detail`, `related`, `search`, `ranking`, `recommended`, `series`, `bookmarkAdd`, `bookmarkDelete` |
+| `illusts` | `detail`, `related`, `search`, `ranking`, `recommended`, `series`, `bookmarkAdd`, `bookmarkDelete`, `trendingTags` |
 | `novels` | `detail`, `text`, `related`, `search`, `ranking`, `recommended`, `series`, `bookmarkAdd`, `bookmarkDelete` |
-| `users` | `detail`, `illusts`, `novels`, `following`, `followAdd`, `followDelete`, `related`, `recommended`, `follower`, `mypixiv`, `list`, `bookmarkTagsIllust`, `editAiShowSettings` |
+| `users` | `detail`, `search`, `illusts`, `novels`, `following`, `followAdd`, `followDelete`, `related`, `recommended`, `follower`, `mypixiv`, `list`, `bookmarkTagsIllust`, `editAiShowSettings` |
 | `users.bookmarks` | `illusts`, `novels` |
 | `manga` | `recommended` |
 | `ugoira` | `metadata` |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,6 +87,8 @@ export type {
   IllustSeriesPage,
   IllustCommentsPage,
   IllustBookmarkDetailResponse,
+  TrendingTagIllust,
+  TrendingTagsIllustResponse,
   MangaRecommendedPage,
   UgoiraMetadataResponse,
   NovelDetailResponse,
@@ -104,6 +106,7 @@ export type {
   UserRecommendedPage,
   UserFollowerPage,
   UserMypixivPage,
+  UserSearchPage,
   UserListPage,
   BookmarkTag,
   UserBookmarkTagsIllustPage,
@@ -123,6 +126,7 @@ export type {
   IllustCommentsParams,
   IllustBookmarkDetailParams,
   IllustNewParams,
+  IllustTrendingTagsParams,
 } from './resources/illusts'
 
 export type {
@@ -156,6 +160,7 @@ export type {
   UserListParams,
   UserBookmarkTagsIllustParams,
   UserEditAiShowSettingsParams,
+  UserSearchParams,
 } from './resources/users'
 
 // PixivClient

--- a/packages/core/src/resources/illusts.ts
+++ b/packages/core/src/resources/illusts.ts
@@ -24,6 +24,7 @@ import type {
   IllustListPage,
   IllustRecommendedPage,
   IllustSeriesPage,
+  TrendingTagsIllustResponse,
 } from '../types'
 
 // === Request param types ===
@@ -172,6 +173,12 @@ export interface IllustNewParams {
   filter?: (typeof OSFilter)[keyof typeof OSFilter]
   /** Cursor: fetch illusts posted before this illust ID. */
   maxIllustId?: number
+}
+
+/** Parameters for fetching trending illust tags. */
+export interface IllustTrendingTagsParams {
+  /** OS filter to apply (default: `"for_ios"`). */
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
 }
 
 /** Methods for the illust API namespace. */
@@ -473,6 +480,21 @@ export class IllustResource {
       ),
       this.#http,
       (page) => page.illusts
+    )
+  }
+
+  /**
+   * Fetches currently trending illust tags, each with a representative illust.
+   * GET /v1/trending-tags/illust
+   *
+   * @param params - Request parameters
+   */
+  trendingTags(
+    params: IllustTrendingTagsParams = {}
+  ): ResultAsync<TrendingTagsIllustResponse, PixivError> {
+    return this.#http.get<TrendingTagsIllustResponse>(
+      '/v1/trending-tags/illust',
+      buildParams({ filter: params.filter ?? 'for_ios' })
     )
   }
 }

--- a/packages/core/src/resources/users.ts
+++ b/packages/core/src/resources/users.ts
@@ -10,6 +10,8 @@ import {
   BookmarkRestrict,
   FollowRestrict,
   OSFilter,
+  SearchDuration,
+  SearchSort,
   UserIllustType,
 } from '../options'
 import type {
@@ -30,6 +32,7 @@ import type {
   UserNovelsPage,
   UserRecommendedPage,
   UserRelatedPage,
+  UserSearchPage,
 } from '../types'
 
 // === Request param types ===
@@ -176,6 +179,20 @@ export interface UserBookmarkTagsIllustParams {
   offset?: number
 }
 
+/** Parameters for searching users. */
+export interface UserSearchParams {
+  /** Search keyword. */
+  word: string
+  /** Sort order for results (default: `"date_desc"`). */
+  sort?: (typeof SearchSort)[keyof typeof SearchSort]
+  /** Date range preset filter (omit for no restriction). */
+  duration?: (typeof SearchDuration)[keyof typeof SearchDuration]
+  /** OS filter to apply (default: `"for_ios"`). */
+  filter?: (typeof OSFilter)[keyof typeof OSFilter]
+  /** Zero-based offset for pagination. */
+  offset?: number
+}
+
 /** Parameters for editing the AI-generated-work display setting. */
 export interface UserEditAiShowSettingsParams {
   /** New display setting value: `0` = hide AI works, `1` = show AI works. */
@@ -294,6 +311,39 @@ export class UserResource {
     return this.#http.get<UserDetailResponse>(
       '/v1/user/detail',
       buildParams({ userId: params.userId, filter: params.filter ?? 'for_ios' })
+    )
+  }
+
+  /**
+   * Searches for users.
+   * GET /v1/search/user
+   *
+   * @param params - Request parameters
+   *
+   * @example
+   * ```ts
+   * // Iterate all results across pages
+   * for await (const preview of client.users.search({ word: 'artist' }).items()) {
+   *   console.log(preview.user.name)
+   * }
+   * ```
+   */
+  search(
+    params: UserSearchParams
+  ): PaginatedResultAsync<UserSearchPage, PixivUserPreviewItem> {
+    return PaginatedResultAsync.fromResultAsync(
+      this.#http.get<UserSearchPage>(
+        '/v1/search/user',
+        buildParams({
+          word: params.word,
+          sort: params.sort ?? 'date_desc',
+          duration: params.duration,
+          filter: params.filter ?? 'for_ios',
+          offset: params.offset,
+        })
+      ),
+      this.#http,
+      (page) => page.userPreviews
     )
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -611,6 +611,24 @@ export interface IllustSeriesPage {
   nextUrl: string | null
 }
 
+/**
+ * A single trending tag entry, paired with a representative illust.
+ */
+export interface TrendingTagIllust {
+  /** Tag name in Japanese. */
+  tag: string
+  /** Translated tag name, or `null` if no translation is available. */
+  translatedName: string | null
+  /** Representative illust for this tag. */
+  illust: PixivIllustItem
+}
+
+/** Response shape for GET /v1/trending-tags/illust. */
+export interface TrendingTagsIllustResponse {
+  /** Currently trending tags, each with a representative illust. */
+  trendTags: TrendingTagIllust[]
+}
+
 // Manga endpoint responses
 
 /** Page response for GET /v1/manga/recommended. */
@@ -781,6 +799,16 @@ export interface UserMypixivPage {
   userPreviews: PixivUserPreviewItem[]
   /** URL to the next page, or `null` when this is the last page. */
   nextUrl: string | null
+}
+
+/** Page response for GET /v1/search/user. */
+export interface UserSearchPage {
+  /** User preview items matching the search. */
+  userPreviews: PixivUserPreviewItem[]
+  /** URL to the next page, or `null` when this is the last page. */
+  nextUrl: string | null
+  /** Maximum number of results the search will return across all pages. */
+  searchSpanLimit: number
 }
 
 /**

--- a/packages/core/tests/e2e/illusts.e2e.test.ts
+++ b/packages/core/tests/e2e/illusts.e2e.test.ts
@@ -177,4 +177,13 @@ describe.skipIf(SKIP)('PixivClient e2e — illusts', () => {
     if (!result.isOk) return
     expect(result.value.illusts.length).toBeGreaterThan(0)
   })
+
+  it('illusts.trendingTags', async () => {
+    const result = await client.illusts.trendingTags()
+    expect(result.isOk).toBe(true)
+    if (!result.isOk) return
+    expect(result.value.trendTags.length).toBeGreaterThan(0)
+    expect(result.value.trendTags[0].tag.length).toBeGreaterThan(0)
+    expect(result.value.trendTags[0].illust.id).toBeGreaterThan(0)
+  })
 })

--- a/packages/core/tests/e2e/users.e2e.test.ts
+++ b/packages/core/tests/e2e/users.e2e.test.ts
@@ -102,6 +102,13 @@ describe.skipIf(SKIP)('PixivClient e2e — users', () => {
     expect(Array.isArray(result.value.users)).toBe(true)
   })
 
+  it('users.search', async () => {
+    const result = await client.users.search({ word: 'pixiv' })
+    expect(result.isOk).toBe(true)
+    if (!result.isOk) return
+    expect(Array.isArray(result.value.userPreviews)).toBe(true)
+  })
+
   it('users.bookmarkTagsIllust', async () => {
     const result = await client.users.bookmarkTagsIllust({
       userId: STAFF_USER_ID,

--- a/packages/core/tests/illusts.test.ts
+++ b/packages/core/tests/illusts.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 import { http, HttpResponse } from 'msw'
 import { server } from './msw/handlers'
 import { PixivClient } from '../src/client'
-import { mockIllustRelated, mockIllustSeries } from './msw/illusts'
+import {
+  mockIllustRelated,
+  mockIllustSeries,
+  mockIllustTrendingTags,
+} from './msw/illusts'
 
 const ILLUST = {
   id: 1,
@@ -613,5 +617,51 @@ describe('illusts.bookmarkDelete()', () => {
     expect(result.isOk).toBe(true)
     const params = new URLSearchParams(capturedBody)
     expect(params.get('illust_id')).toBe('1')
+  })
+})
+
+describe('illusts.trendingTags()', () => {
+  it('returns Ok with trend tags', async () => {
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      mockIllustTrendingTags({
+        trend_tags: [
+          { tag: 'cat', translated_name: 'Cat', illust: ILLUST },
+        ],
+      })
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.illusts.trendingTags()
+    expect(result.isOk).toBe(true)
+    if (result.isOk) {
+      expect(result.value.trendTags).toHaveLength(1)
+      expect(result.value.trendTags[0].tag).toBe('cat')
+      expect(result.value.trendTags[0].translatedName).toBe('Cat')
+      expect(result.value.trendTags[0].illust.id).toBe(1)
+    }
+  })
+
+  it('defaults filter to for_ios', async () => {
+    let capturedUrl: string | undefined
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get(
+        'https://app-api.pixiv.net/v1/trending-tags/illust',
+        ({ request }) => {
+          capturedUrl = request.url
+          return HttpResponse.json({ trend_tags: [] })
+        }
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    await client.illusts.trendingTags()
+    expect(capturedUrl).toBeDefined()
+    if (capturedUrl === undefined) return
+    const params = new URL(capturedUrl).searchParams
+    expect(params.get('filter')).toBe('for_ios')
   })
 })

--- a/packages/core/tests/msw/illusts.ts
+++ b/packages/core/tests/msw/illusts.ts
@@ -23,3 +23,9 @@ export function mockIllustBookmarkDelete(body: JsonBodyType) {
     HttpResponse.json(body)
   )
 }
+
+export function mockIllustTrendingTags(body: JsonBodyType) {
+  return http.get('https://app-api.pixiv.net/v1/trending-tags/illust', () =>
+    HttpResponse.json(body)
+  )
+}

--- a/packages/core/tests/msw/users.ts
+++ b/packages/core/tests/msw/users.ts
@@ -68,3 +68,9 @@ export function mockUserEditAiShowSettings(body: JsonBodyType) {
     () => HttpResponse.json(body)
   )
 }
+
+export function mockUserSearch(body: JsonBodyType) {
+  return http.get('https://app-api.pixiv.net/v1/search/user', () =>
+    HttpResponse.json(body)
+  )
+}

--- a/packages/core/tests/users.test.ts
+++ b/packages/core/tests/users.test.ts
@@ -12,6 +12,7 @@ import {
   mockUserList,
   mockUserBookmarkTagsIllust,
   mockUserEditAiShowSettings,
+  mockUserSearch,
 } from './msw/users'
 
 const NOVEL = {
@@ -736,5 +737,87 @@ describe('users.editAiShowSettings()', () => {
     await client.users.editAiShowSettings({ setting: 1 })
     const params = new URLSearchParams(capturedBody)
     expect(params.get('setting')).toBe('1')
+  })
+})
+
+describe('users.search()', () => {
+  it('returns Ok with user previews', async () => {
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      mockUserSearch({
+        user_previews: [USER_PREVIEW],
+        next_url: null,
+        search_span_limit: 1000,
+      })
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.users.search({ word: 'artist' })
+    expect(result.isOk).toBe(true)
+    if (result.isOk) {
+      expect(result.value.userPreviews).toHaveLength(1)
+      expect(result.value.userPreviews[0].user.id).toBe(99)
+      expect(result.value.searchSpanLimit).toBe(1000)
+    }
+  })
+
+  it('sends word and defaults sort/filter', async () => {
+    let capturedUrl: string | undefined
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get('https://app-api.pixiv.net/v1/search/user', ({ request }) => {
+        capturedUrl = request.url
+        return HttpResponse.json({
+          user_previews: [],
+          next_url: null,
+          search_span_limit: 1000,
+        })
+      })
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    await client.users.search({ word: 'artist' })
+    expect(capturedUrl).toBeDefined()
+    if (capturedUrl === undefined) return
+    const params = new URL(capturedUrl).searchParams
+    expect(params.get('word')).toBe('artist')
+    expect(params.get('sort')).toBe('date_desc')
+    expect(params.get('filter')).toBe('for_ios')
+  })
+
+  it('yields all items across pages', async () => {
+    const USER_PREVIEW2 = {
+      ...USER_PREVIEW,
+      user: { ...USER_PREVIEW.user, id: 100 },
+    }
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      http.get('https://app-api.pixiv.net/v1/search/user', ({ request }) => {
+        const offset = new URL(request.url).searchParams.get('offset')
+        if (offset === '30') {
+          return HttpResponse.json({
+            user_previews: [USER_PREVIEW2],
+            next_url: null,
+            search_span_limit: 1000,
+          })
+        }
+        return HttpResponse.json({
+          user_previews: [USER_PREVIEW],
+          next_url: 'https://app-api.pixiv.net/v1/search/user?offset=30',
+          search_span_limit: 1000,
+        })
+      })
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const ids: number[] = []
+    const previews = client.users.search({ word: 'artist' }).items()
+    for await (const preview of previews) {
+      ids.push(preview.user.id)
+    }
+    expect(ids).toEqual([99, 100])
   })
 })


### PR DESCRIPTION
## Summary

Adds two previously unsupported search/trending endpoints.

## Changes

- `users.search()`: `GET /v1/search/user` — user search, paginated via `PaginatedResultAsync`
  - Params: `word` (required), `sort`, `duration`, `filter`, `offset`
  - Response type `UserSearchPage`: `userPreviews`, `nextUrl`, `searchSpanLimit`
- `illusts.trendingTags()`: `GET /v1/trending-tags/illust` — trending tags with a representative illust each; single non-paginated response
  - Response type `TrendingTagsIllustResponse`: `trendTags: { tag, translatedName, illust }[]`
  - Modeled `tag`/`translatedName` as flat string fields (not a nested `Tag` object), matching the live API shape confirmed against reference client implementations and verified end-to-end against the real pixiv API
- Updated the resource table in `README.md`
- Added unit tests (with MSW mocks) and e2e tests for both endpoints

## Verification

- `pnpm lint`: no errors
- `pnpm test`: all 226 unit tests pass
- `pnpm --filter @book000/pixivts test:e2e`: all e2e tests pass against the real pixiv API, including the new `users.search` and `illusts.trendingTags` cases
- `pnpm --filter @book000/pixivts build` and `build:dts-guard`: pass