### PR TITLE
feat(core): return structured WebviewNovel from novels.text()

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -226,3 +226,32 @@ console.log(client.getRefreshToken()) // current refresh token
 ### DB Recording
 
 The `@book000/pixivts-db-mysql` package continues to save **raw snake_case** response bodies to the database for archival fidelity. This behaviour is unchanged.
+
+---
+
+# Migration Guide: ≤ 0.62.x → ≥ 0.63.0
+
+## `novels.text()`: string → `WebviewNovel`
+
+`client.novels.text()` previously resolved to the raw HTML body of the WebView
+novel page. It now parses that page and resolves to a structured
+`WebviewNovel` object (title, tags, rating counters, series navigation, body
+text, etc.), matching the response shape of other endpoints in this library.
+This is a **breaking change**.
+
+```typescript
+// ≤ 0.62.x
+const result = await client.novels.text({ novelId })
+if (result.isOk) {
+  const html = result.value // raw HTML string
+}
+
+// ≥ 0.63.0
+const result = await client.novels.text({ novelId })
+if (result.isOk) {
+  const novel = result.value // WebviewNovel
+  console.log(novel.title, novel.text)
+} else if (result.error.type === 'parse_error') {
+  // the embedded novel data could not be located or parsed
+}
+```

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -36,6 +36,16 @@ export type PixivError =
       /** Parsed response body (object if JSON, string otherwise). */
       body: unknown
     }
+  | {
+      /** Structured data embedded in a non-JSON response could not be extracted or parsed. */
+      type: 'parse_error'
+      /** Description of what failed to parse. */
+      message: string
+      /** Raw response body that failed to parse. */
+      body: string
+      /** The underlying error thrown during parsing, if any (e.g. a `SyntaxError` from `JSON.parse`). */
+      cause?: unknown
+    }
 
 // ---------------------------------------------------------------------------
 // PixivFetchError — a proper Error subclass wrapping PixivError
@@ -95,4 +105,13 @@ export function networkError(cause: unknown): PixivError {
 /** Creates an API error. */
 export function apiError(status: number, body: unknown): PixivError {
   return { type: 'api_error', status, body }
+}
+
+/** Creates a parse error. */
+export function parseError(
+  message: string,
+  body: string,
+  cause?: unknown
+): PixivError {
+  return { type: 'parse_error', message, body, cause }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export {
   authFailedError,
   networkError,
   apiError,
+  parseError,
   PixivFetchError,
 } from './errors'
 export type { PixivError } from './errors'
@@ -96,6 +97,10 @@ export type {
   NovelRecommendedPage,
   NovelSeriesPage,
   NovelCommentsPage,
+  WebviewNovelRating,
+  WebviewNovelNavigationInfo,
+  WebviewNovelSeriesNavigation,
+  WebviewNovel,
   UserDetailResponse,
   UserIllustsPage,
   UserNovelsPage,

--- a/packages/core/src/resources/novels.ts
+++ b/packages/core/src/resources/novels.ts
@@ -6,6 +6,7 @@ import type { PixivError } from '../errors'
 import { buildParams } from '../params'
 import { PaginatedResultAsync } from '../paginated'
 import type { ResultAsync } from '../result'
+import { parseWebviewNovel } from '../webview-novel'
 import {
   BookmarkRestrict,
   FollowRestrict,
@@ -23,6 +24,7 @@ import type {
   NovelRecommendedPage,
   NovelSeriesPage,
   PixivNovelItem,
+  WebviewNovel,
 } from '../types'
 
 // === Request param types ===
@@ -176,20 +178,26 @@ export class NovelResource {
   }
 
   /**
-   * Fetches the WebView HTML for a novel.
+   * Fetches the structured content of a novel's WebView page.
    * GET /webview/v2/novel
    *
-   * Returns the raw HTML page that the pixiv app renders in a WebView.
-   * To extract the plain text, parse the returned HTML (e.g. strip tags).
+   * The endpoint itself returns an HTML page that the pixiv app renders in a
+   * WebView; this method extracts the `WebviewNovel` object embedded in that
+   * page (body text, rating counters, series navigation, etc.) so callers
+   * don't need to parse HTML themselves.
    *
    * @param params - Request parameters
+   * @returns `Err` with `type: 'parse_error'` if the embedded data cannot be
+   *   located or parsed
    */
-  text(params: NovelTextParams): ResultAsync<string, PixivError> {
-    return this.#http.get<string>(
-      '/webview/v2/novel',
-      // The webview endpoint uses the query parameter 'id', not 'novel_id'
-      buildParams({ id: params.novelId })
-    )
+  text(params: NovelTextParams): ResultAsync<WebviewNovel, PixivError> {
+    return this.#http
+      .get<string>(
+        '/webview/v2/novel',
+        // The webview endpoint uses the query parameter 'id', not 'novel_id'
+        buildParams({ id: params.novelId, viewerVersion: '20221031_ai' })
+      )
+      .andThen(parseWebviewNovel)
   }
 
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -711,6 +711,90 @@ export interface NovelSeriesPage {
   nextUrl: string | null
 }
 
+/** Bookmark / view counters embedded in a WebView novel page. */
+export interface WebviewNovelRating {
+  /** Number of "likes" (lightweight reactions). */
+  like: number
+  /** Number of bookmarks. */
+  bookmark: number
+  /** Number of views. */
+  view: number
+}
+
+/** Navigation info for a sibling novel in a series, as embedded in the WebView novel page. */
+export interface WebviewNovelNavigationInfo {
+  /** Work ID of the sibling novel. */
+  id: number
+  /** Whether the authenticated user is allowed to view this novel. */
+  viewable: boolean
+  /** Position of the novel within the series' reading order. */
+  contentOrder: string
+  /** Title of the sibling novel. */
+  title: string
+  /** Cover image URL of the sibling novel. */
+  coverUrl: string
+  /** Reason the novel is not viewable (present only when `viewable` is `false`). */
+  viewableMessage?: string | null
+}
+
+/** Prev/next navigation for a novel that belongs to a series, as embedded in the WebView novel page. */
+export interface WebviewNovelSeriesNavigation {
+  /** Previous novel in the series (`null` or absent if this is the first). */
+  prev?: WebviewNovelNavigationInfo | null
+  /** Next novel in the series (`null` or absent if this is the latest). */
+  next?: WebviewNovelNavigationInfo | null
+}
+
+/**
+ * Structured novel content parsed from the WebView HTML page.
+ *
+ * Returned by `client.novels.text()` (GET /webview/v2/novel). pixiv embeds
+ * this data as a JavaScript object literal inside the HTML page rather than
+ * returning JSON directly, so several id-like fields are strings rather than
+ * numbers — unlike the numeric ids used throughout the rest of this library.
+ */
+export interface WebviewNovel {
+  /** Work ID, as a string. */
+  id: string
+  /** Title of the novel. */
+  title: string
+  /** Series ID (`null` or absent if the novel does not belong to a series). */
+  seriesId?: string | null
+  /** Series title (`null` or absent if the novel does not belong to a series). */
+  seriesTitle?: string | null
+  /**
+   * Whether the authenticated user is watching (following) the series
+   * (`null` or absent if the novel does not belong to a series).
+   */
+  seriesIsWatched?: boolean | null
+  /** Author's user ID, as a string. */
+  userId: string
+  /** Cover image URL. */
+  coverUrl: string
+  /** Tags attached to the novel. */
+  tags: string[]
+  /** Synopsis / caption (may contain HTML). */
+  caption: string
+  /** ISO 8601 date-time string of when the novel was posted. */
+  cdate: string
+  /** Like / bookmark / view counters. */
+  rating: WebviewNovelRating
+  /** Full novel body text. */
+  text: string
+  /** Reading-position marker for the authenticated user (`null` or absent if none). */
+  marker?: string | null
+  /**
+   * Prev/next navigation for the series this novel belongs to.
+   *
+   * `{}` (empty object) if the novel does not belong to a series.
+   */
+  seriesNavigation: WebviewNovelSeriesNavigation | Record<string, never>
+  /** AI-generated content flag: 0 = no AI, 1 = partial AI, 2 = fully AI */
+  aiType: number
+  /** Whether the novel is an original work (not fan fiction). */
+  isOriginal: boolean
+}
+
 // User endpoint responses
 
 /** Response shape for GET /v1/user/detail. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -786,9 +786,11 @@ export interface WebviewNovel {
   /**
    * Prev/next navigation for the series this novel belongs to.
    *
-   * `{}` (empty object) if the novel does not belong to a series.
+   * `null` if the novel does not belong to a series (confirmed against real
+   * WebView responses — pixiv sends this field as `null`, not `{}`, in that
+   * case).
    */
-  seriesNavigation: WebviewNovelSeriesNavigation | Record<string, never>
+  seriesNavigation: WebviewNovelSeriesNavigation | null
   /** AI-generated content flag: 0 = no AI, 1 = partial AI, 2 = fully AI */
   aiType: number
   /** Whether the novel is an original work (not fan fiction). */

--- a/packages/core/src/webview-novel.ts
+++ b/packages/core/src/webview-novel.ts
@@ -1,0 +1,79 @@
+/**
+ * Parses the structured novel data embedded in the WebView HTML page
+ * (GET /webview/v2/novel).
+ */
+import { parseError } from './errors'
+import { camelizeKeys } from './params'
+import { err, ok } from './result'
+import type { PixivError } from './errors'
+import type { Result } from './result'
+import type { WebviewNovel } from './types'
+
+// The page embeds the novel data as a JavaScript object literal assigned to
+// a `novel` property, immediately followed by `isOwnWork`. There is no
+// surrounding JSON document to parse instead, so pixivpy's approach — a
+// regex extracting the object literal — is followed here too. The pattern
+// is neither anchored to a unique prefix nor lazy, matching from the first
+// `novel:` to the last `isOwnWork` in the page; this is a known limitation
+// shared with pixivpy (unverified against a real page containing more than
+// one such token), so the shape check below guards against a wrong span
+// that still happens to be syntactically valid JSON.
+const NOVEL_JSON_PATTERN = /novel:\s*({.+}),\s*isOwnWork/s
+
+/**
+ * Verifies that a parsed value has the fields a `WebviewNovel` requires,
+ * so a syntactically valid but wrong-span capture (see `NOVEL_JSON_PATTERN`)
+ * is rejected instead of silently returned as if it were the requested novel.
+ */
+function isWebviewNovelShape(value: unknown): value is WebviewNovel {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as Record<string, unknown>
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.title === 'string' &&
+    typeof candidate.userId === 'string' &&
+    typeof candidate.text === 'string'
+  )
+}
+
+/**
+ * Extracts and parses the `WebviewNovel` object embedded in a WebView novel
+ * HTML page.
+ *
+ * @param html - Raw HTML body returned by GET /webview/v2/novel
+ * @returns `Result<WebviewNovel, PixivError>` — `err` with `type: 'parse_error'`
+ *   if the embedded JSON cannot be located, parsed, or does not have the
+ *   expected `WebviewNovel` shape
+ */
+export function parseWebviewNovel(html: string): Result<WebviewNovel, PixivError> {
+  const match = NOVEL_JSON_PATTERN.exec(html)
+  if (!match) {
+    return err(
+      parseError('Could not find embedded novel JSON in WebView HTML', html)
+    )
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(match[1])
+  } catch (error: unknown) {
+    return err(
+      parseError(
+        `Failed to parse embedded novel JSON: ${String(error)}`,
+        html,
+        error
+      )
+    )
+  }
+
+  const camelized = camelizeKeys(parsed)
+  if (!isWebviewNovelShape(camelized)) {
+    return err(
+      parseError(
+        'Embedded novel JSON does not match the expected WebviewNovel shape',
+        html
+      )
+    )
+  }
+  return ok(camelized)
+}

--- a/packages/core/tests/e2e/novels.e2e.test.ts
+++ b/packages/core/tests/e2e/novels.e2e.test.ts
@@ -30,8 +30,8 @@ describe.skipIf(SKIP)('PixivClient e2e — novels', () => {
     const result = await client.novels.text({ novelId: NOVEL_ID })
     expect(result.isOk).toBe(true)
     if (!result.isOk) return
-    // novels.text returns the raw novel text as a string
-    expect(result.value.length).toBeGreaterThan(0)
+    expect(result.value.id).toBe(String(NOVEL_ID))
+    expect(result.value.text.length).toBeGreaterThan(0)
   })
 
   it('novels.related', async () => {

--- a/packages/core/tests/novels.test.ts
+++ b/packages/core/tests/novels.test.ts
@@ -52,6 +52,32 @@ const AUTH_RESPONSE = {
   },
 }
 
+/** Wraps a WebviewNovel-shaped object literal in the HTML pixiv's WebView page embeds it in. */
+function webviewNovelHtml(novel: Record<string, unknown>): string {
+  return `<html><body><script>pixiv.context.novel = {novel: ${JSON.stringify(
+    novel
+  )}, isOwnWork: false, isMuteAll: false}</script></body></html>`
+}
+
+const WEBVIEW_NOVEL = {
+  id: '100',
+  title: 'Test Novel',
+  series_id: undefined,
+  series_title: undefined,
+  series_is_watched: undefined,
+  user_id: '42',
+  cover_url: 'https://i.pximg.net/c.jpg',
+  tags: ['tag1', 'tag2'],
+  caption: 'A caption',
+  cdate: '2024-01-01T00:00:00+09:00',
+  rating: { like: 10, bookmark: 20, view: 500 },
+  text: 'Chapter 1 text',
+  marker: undefined,
+  series_navigation: {},
+  ai_type: 0,
+  is_original: false,
+}
+
 describe('novels.detail()', () => {
   it('returns Ok with the novel', async () => {
     server.use(
@@ -294,22 +320,24 @@ describe('novels.new()', () => {
 })
 
 describe('novels.text()', () => {
-  it('returns Ok with the raw WebView HTML', async () => {
+  it('returns Ok with the parsed WebviewNovel', async () => {
     server.use(
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
         HttpResponse.json(AUTH_RESPONSE)
       ),
-      mockNovelText('<html><body>Chapter 1 text</body></html>')
+      mockNovelText(webviewNovelHtml(WEBVIEW_NOVEL))
     )
     const client = await PixivClient.of('test-refresh-token')
     const result = await client.novels.text({ novelId: 100 })
     expect(result.isOk).toBe(true)
-    if (result.isOk) {
-      expect(result.value).toContain('Chapter 1 text')
-    }
+    if (!result.isOk) return
+    expect(result.value.id).toBe('100')
+    expect(result.value.text).toBe('Chapter 1 text')
+    expect(result.value.rating).toEqual({ like: 10, bookmark: 20, view: 500 })
+    expect(result.value.seriesId).toBeUndefined()
   })
 
-  it('passes id (not novel_id) in the query string', async () => {
+  it('passes id (not novel_id) and viewer_version in the query string', async () => {
     let capturedUrl: string | undefined
     server.use(
       http.post('https://oauth.secure.pixiv.net/auth/token', () =>
@@ -317,7 +345,7 @@ describe('novels.text()', () => {
       ),
       http.get('https://app-api.pixiv.net/webview/v2/novel', ({ request }) => {
         capturedUrl = request.url
-        return HttpResponse.text('<html></html>')
+        return HttpResponse.text(webviewNovelHtml(WEBVIEW_NOVEL))
       })
     )
     const client = await PixivClient.of('test-refresh-token')
@@ -327,6 +355,37 @@ describe('novels.text()', () => {
     const params = new URL(capturedUrl).searchParams
     expect(params.get('id')).toBe('100')
     expect(params.has('novel_id')).toBe(false)
+    expect(params.get('viewer_version')).toBe('20221031_ai')
+  })
+
+  it('returns Err with type parse_error when the embedded JSON cannot be found', async () => {
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      mockNovelText('<html><body>not a webview page</body></html>')
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.novels.text({ novelId: 100 })
+    expect(result.isOk).toBe(false)
+    if (result.isOk) return
+    expect(result.error.type).toBe('parse_error')
+  })
+
+  it('returns Err with type parse_error when the embedded JSON is malformed', async () => {
+    server.use(
+      http.post('https://oauth.secure.pixiv.net/auth/token', () =>
+        HttpResponse.json(AUTH_RESPONSE)
+      ),
+      mockNovelText(
+        '<html><body><script>pixiv.context.novel = {novel: {id: "100", not valid json}, isOwnWork: false}</script></body></html>'
+      )
+    )
+    const client = await PixivClient.of('test-refresh-token')
+    const result = await client.novels.text({ novelId: 100 })
+    expect(result.isOk).toBe(false)
+    if (result.isOk) return
+    expect(result.error.type).toBe('parse_error')
   })
 })
 

--- a/packages/core/tests/webview-novel.test.ts
+++ b/packages/core/tests/webview-novel.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import { parseWebviewNovel } from '../src/webview-novel'
+
+function webviewNovelHtml(novel: Record<string, unknown>): string {
+  return `<html><body><script>pixiv.context.novel = {novel: ${JSON.stringify(
+    novel
+  )}, isOwnWork: false, isMuteAll: false}</script></body></html>`
+}
+
+describe('parseWebviewNovel()', () => {
+  it('parses a WebviewNovel object embedded in the HTML page', () => {
+    const html = webviewNovelHtml({
+      id: '100',
+      title: 'Test Novel',
+      user_id: '42',
+      cover_url: 'https://i.pximg.net/c.jpg',
+      tags: ['tag1'],
+      caption: '',
+      cdate: '2024-01-01T00:00:00+09:00',
+      rating: { like: 1, bookmark: 2, view: 3 },
+      text: 'body text',
+      series_navigation: {},
+      ai_type: 0,
+      is_original: true,
+    })
+
+    const result = parseWebviewNovel(html)
+    expect(result.isOk).toBe(true)
+    if (!result.isOk) return
+    expect(result.value.id).toBe('100')
+    expect(result.value.userId).toBe('42')
+    expect(result.value.rating).toEqual({ like: 1, bookmark: 2, view: 3 })
+    expect(result.value.isOriginal).toBe(true)
+  })
+
+  it('parses nested series navigation', () => {
+    const html = webviewNovelHtml({
+      id: '100',
+      title: 'Test Novel',
+      user_id: '42',
+      cover_url: 'https://i.pximg.net/c.jpg',
+      tags: [],
+      caption: '',
+      cdate: '2024-01-01T00:00:00+09:00',
+      rating: { like: 0, bookmark: 0, view: 0 },
+      text: 'body text',
+      series_navigation: {
+        next: {
+          id: 101,
+          viewable: true,
+          content_order: '2',
+          title: 'Next Chapter',
+          cover_url: 'https://i.pximg.net/n.jpg',
+        },
+      },
+      ai_type: 0,
+      is_original: true,
+    })
+
+    const result = parseWebviewNovel(html)
+    expect(result.isOk).toBe(true)
+    if (!result.isOk) return
+    expect(result.value.seriesNavigation).toEqual({
+      next: {
+        id: 101,
+        viewable: true,
+        contentOrder: '2',
+        title: 'Next Chapter',
+        coverUrl: 'https://i.pximg.net/n.jpg',
+      },
+    })
+  })
+
+  it('parses explicit null values for series/marker fields', () => {
+    const html = webviewNovelHtml({
+      id: '100',
+      title: 'Test Novel',
+      series_id: null,
+      series_title: null,
+      series_is_watched: null,
+      user_id: '42',
+      cover_url: 'https://i.pximg.net/c.jpg',
+      tags: [],
+      caption: '',
+      cdate: '2024-01-01T00:00:00+09:00',
+      rating: { like: 0, bookmark: 0, view: 0 },
+      text: 'body text',
+      marker: null,
+      series_navigation: {},
+      ai_type: 0,
+      is_original: true,
+    })
+
+    const result = parseWebviewNovel(html)
+    expect(result.isOk).toBe(true)
+    if (!result.isOk) return
+    expect(result.value.seriesId).toBeNull()
+    expect(result.value.seriesTitle).toBeNull()
+    expect(result.value.seriesIsWatched).toBeNull()
+    expect(result.value.marker).toBeNull()
+  })
+
+  it('returns an Err with type parse_error when no embedded JSON is found', () => {
+    const result = parseWebviewNovel('<html><body>no data here</body></html>')
+    expect(result.isOk).toBe(false)
+    if (result.isOk) return
+    expect(result.error.type).toBe('parse_error')
+  })
+
+  it('returns an Err with type parse_error and a cause when the embedded JSON is malformed', () => {
+    const html =
+      '<script>pixiv.context.novel = {novel: {id: "100", not valid json}, isOwnWork: false}</script>'
+    const result = parseWebviewNovel(html)
+    expect(result.isOk).toBe(false)
+    if (result.isOk) return
+    expect(result.error.type).toBe('parse_error')
+    if (result.error.type !== 'parse_error') return
+    expect(result.error.cause).toBeInstanceOf(SyntaxError)
+  })
+
+  it('returns an Err with type parse_error when the embedded JSON does not match the WebviewNovel shape', () => {
+    const html = webviewNovelHtml({ unrelated: 'data' })
+    const result = parseWebviewNovel(html)
+    expect(result.isOk).toBe(false)
+    if (result.isOk) return
+    expect(result.error.type).toBe('parse_error')
+  })
+})

--- a/packages/core/tests/webview-novel.test.ts
+++ b/packages/core/tests/webview-novel.test.ts
@@ -19,7 +19,7 @@ describe('parseWebviewNovel()', () => {
       cdate: '2024-01-01T00:00:00+09:00',
       rating: { like: 1, bookmark: 2, view: 3 },
       text: 'body text',
-      series_navigation: {},
+      series_navigation: null,
       ai_type: 0,
       is_original: true,
     })
@@ -31,6 +31,7 @@ describe('parseWebviewNovel()', () => {
     expect(result.value.userId).toBe('42')
     expect(result.value.rating).toEqual({ like: 1, bookmark: 2, view: 3 })
     expect(result.value.isOriginal).toBe(true)
+    expect(result.value.seriesNavigation).toBeNull()
   })
 
   it('parses nested series navigation', () => {


### PR DESCRIPTION
## Overview

`client.novels.text()` previously resolved to the raw HTML body of the WebView novel page (`GET /webview/v2/novel`), leaving HTML parsing to the caller. It now parses that page and resolves to a structured `WebviewNovel` object (title, tags, rating counters, series navigation, body text, etc.), matching the response shape of other endpoints in this library. This is a breaking change.

## Changes

- Add `WebviewNovel`, `WebviewNovelRating`, `WebviewNovelNavigationInfo`, and `WebviewNovelSeriesNavigation` types
- Add `parseWebviewNovel()` (`src/webview-novel.ts`) to extract the embedded novel object from the WebView HTML via regex + `JSON.parse`, then validate its shape before returning it — guarding against a wrong regex-span match that still happens to be syntactically valid JSON
- Add a `parse_error` `PixivError` variant (with a `cause` field) for cases where the embedded data cannot be located, parsed, or validated
- Update `docs/migration.md` with the breaking change

## Verification

- `pnpm --filter @book000/pixivts lint` (`tsc`) — no errors
- `pnpm test` — 234/234 tests pass across 15 test files
- `pnpm build` and `pnpm --filter @book000/pixivts build:dts-guard` — pass
- `pnpm lint` (full monorepo) — 0 errors, 1 pre-existing unrelated warning in `src/result.ts`
- E2E suite (`tests/e2e/novels.e2e.test.ts`) type-checks and runs; gracefully skipped in this environment (no `PIXIV_REFRESH_TOKEN`)
